### PR TITLE
fix: templates not working because of wrong valuesFile path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,7 @@ RUN apk add --no-cache ca-certificates && update-ca-certificates
 COPY --from=backend-build /swarm-cd /app/
 # Copy the built frontend from the frontend build stage
 COPY --from=frontend-build /ui/dist/ /app/ui/
+# Sets the web server mode to release
+ENV GIN_MODE=release
 # Set the entry point for the application
 CMD ["/app/swarm-cd"]

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -161,8 +161,8 @@ func discoverSecrets(composeMap map[string]any, composePath string) ([]string, e
 			if !ok {
 				return nil, fmt.Errorf("invalid compose file: %s file field must be a string", secretName)
 			}
-			objectDir := path.Join(path.Dir(composePath), secretFile)
-			sopsFiles = append(sopsFiles, objectDir)
+			secretPath := path.Join(path.Dir(composePath), secretFile)
+			sopsFiles = append(sopsFiles, secretPath)
 		}
 	}
 	return sopsFiles, nil

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -102,7 +102,7 @@ func (swarmStack *swarmStack) readStack() ([]byte, error) {
 }
 
 func (swarmStack *swarmStack) renderComposeTemplate(templateContents []byte) ([]byte, error) {
-	valuesFile := path.Join(config.ReposPath, swarmStack.repo.path, swarmStack.valuesFile)
+	valuesFile := path.Join(swarmStack.repo.path, swarmStack.valuesFile)
 	valuesBytes, err := os.ReadFile(valuesFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read %s stack values file: %w", swarmStack.name, err)

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -13,7 +13,7 @@ func Run() {
 	logger.Info("starting SwarmCD")
 	for {
 		var waitGroup sync.WaitGroup
-		logger.Info("updating stacks...")	
+		logger.Info("updating stacks...")
 		for _, swarmStack := range stacks {
 			waitGroup.Add(1)
 			go updateStackThread(swarmStack, &waitGroup)
@@ -32,7 +32,7 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 
 	logger.Info(fmt.Sprintf("updating %s stack", swarmStack.name))
 	revision, err := swarmStack.updateStack()
-	if err != nil{
+	if err != nil {
 		stackStatus[swarmStack.name].Error = err.Error()
 		logger.Error(err.Error())
 		return
@@ -42,8 +42,6 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	stackStatus[swarmStack.name].Revision = revision
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }
-
-
 
 func GetStackStatus() map[string]*StackStatus {
 	return stackStatus

--- a/util/config.go
+++ b/util/config.go
@@ -66,11 +66,7 @@ func readConfig() (err error) {
 	if err != nil && !errors.As(err, &viper.ConfigFileNotFoundError{}) {
 		return
 	}
-	err = configViper.Unmarshal(&Configs)
-	if err != nil {
-		return
-	}
-	return
+	return configViper.Unmarshal(&Configs)
 }
 
 func readRepoConfigs() (err error) {
@@ -81,11 +77,7 @@ func readRepoConfigs() (err error) {
 	if err != nil {
 		return
 	}
-	err = reposViper.Unmarshal(&Configs.RepoConfigs)
-	if err != nil {
-		return
-	}
-	return
+	return reposViper.Unmarshal(&Configs.RepoConfigs)
 }
 
 func readStackConfigs() (err error) {
@@ -96,9 +88,5 @@ func readStackConfigs() (err error) {
 	if err != nil {
 		return
 	}
-	err = stacksViper.Unmarshal(&Configs.StackConfigs)
-	if err != nil {
-		return
-	}
-	return
+	return stacksViper.Unmarshal(&Configs.StackConfigs)
 }


### PR DESCRIPTION
EDIT: I just started to use the templating engine and I realized there was an error on the composition of the valuesFile path (the `repos` folder was added twice to the path).

The rest of the commits  are still there:

Hi there. these are minor changes to format the code and add debug messages to secrets decrypting (just to check if secrets are correctly found by the automatic discovery) and object rotation.

I also silenced the annoying gin message on the docker by setting it in release mode