### PR TITLE
fix: missing rotateObjects parameter in tests

### DIFF
--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -12,7 +12,7 @@ func TestRotateExternalObjects(t *testing.T) {
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 	}
-	err := stack.rotateObjects(objects)
+	err := stack.rotateObjects(objects, "secrets")
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
This resolves the CI error I introduced by merging my two PRs too quickly :sweat_smile: 
