### PR TITLE
feat: enable gpg decryption with sops (#123)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,4 @@ ENV GIN_MODE=release
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/app/swarm-cd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go test ./swarmcd/
 # Stage 3: Final production image (depends on previous stages)
 FROM alpine:3.22.1
 WORKDIR /app
-RUN apk add --no-cache ca-certificates && update-ca-certificates
+RUN apk add --no-cache ca-certificates gnupg && update-ca-certificates
 # Copy the built backend binary from the backend build stage
 COPY --from=backend-build /swarm-cd /app/
 # Copy the built frontend from the frontend build stage
@@ -31,4 +31,6 @@ COPY --from=frontend-build /ui/dist/ /app/ui/
 # Sets the web server mode to release
 ENV GIN_MODE=release
 # Set the entry point for the application
-CMD ["/app/swarm-cd"]
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ can be a little different:
 to encrypt, you have to mount the age key file to SwarmCD
 and set the environment variable SOPS `SOPS_AGE_KEY_FILE`
 to the path of the key file.
-- If you used gpg, you have to set the environment variable
-`SOPS_GPG_PRIVATE_KEY` to your gpg private key.
+- If you used gpg, you have to mount the file containing your gpg private
+key in the container, and set the environment variable
+`SOPS_GPG_PRIVATE_KEY_FILE` to the path of the gpg private key file.
+It is also possible to directly provide the gpg key in the `SOPS_GPG_PRIVATE_KEY`
+environment variable.
 
 See the following docker-compose example.
 
@@ -103,11 +106,11 @@ services:
           - node.role == manager
     secrets:
       - source: age
-        target: /secrets/age.key
+        target: /secrets/age.key # or /secrets/private.gpg
     environment:
       - SOPS_AGE_KEY_FILE=/secrets/age.key
       # or
-      - SOPS_GPG_PRIVATE_KEY="-----BEGIN PGP PRIVATE KEY BLOCK-----"
+      - SOPS_GPG_PRIVATE_KEY=/secrets/private.gpg
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./repos.yaml:/app/repos.yaml:ro

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ services:
     environment:
       - SOPS_AGE_KEY_FILE=/secrets/age.key
       # or
-      - SOPS_GPG_PRIVATE_KEY=/secrets/private.gpg
+      - SOPS_GPG_PRIVATE_KEY_FILE=/secrets/private.gpg
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./repos.yaml:/app/repos.yaml:ro

--- a/README.md
+++ b/README.md
@@ -81,10 +81,16 @@ nginx-ssl:
 
 Then you need to set the SOPS environment variables that are required
 to decrypt the files.
-For example, if you used [age](https://github.com/FiloSottile/age)
-to encrypt them, you have to mount the age key file to SwarmCD
+Depending on the backend you used for sops encryption, the configuration
+can be a little different:
+- If you used [age](https://github.com/FiloSottile/age)
+to encrypt, you have to mount the age key file to SwarmCD
 and set the environment variable SOPS `SOPS_AGE_KEY_FILE`
-to the path of the key file. See the following docker-compose example
+to the path of the key file.
+- If you used gpg, you have to set the environment variable
+`SOPS_GPG_PRIVATE_KEY` to your gpg private key.
+
+See the following docker-compose example.
 
 ```yaml
 version: '3.7'
@@ -100,6 +106,8 @@ services:
         target: /secrets/age.key
     environment:
       - SOPS_AGE_KEY_FILE=/secrets/age.key
+      # or
+      - SOPS_GPG_PRIVATE_KEY="-----BEGIN PGP PRIVATE KEY BLOCK-----"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./repos.yaml:/app/repos.yaml:ro

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,10 +14,4 @@ else
     echo "entrypoint.sh: no gpg key found, skipping import"
 fi
 
-# Call the app
-if [ -z $@ ]; then
-    echo "entrypoint.sh: starting SwarmCD..."
-	/app/swarm-cd
-else
-	exec "$@"
-fi
+exec /app/swarm-cd "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Swarm-CD entrypoint, used to import gpg keys if needed
+# SwarmCD entrypoint, used to import gpg keys if needed
 if [ ! -z "${SOPS_GPG_PRIVATE_KEY_FILE}" ]; then
     echo "entrypoint.sh: importing gpg private key from file..."
 
-    cat "${SOPS_GPG_PRIVATE_KEY_FILE}" | gpg --import
+    gpg --import "${SOPS_GPG_PRIVATE_KEY_FILE}"
 
     if [ $? -ne 0 ]; then
         echo "entrypoint.sh: error: could not import GPG private key from file !"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,5 +19,5 @@ if [ -z $@ ]; then
     echo "entrypoint.sh: starting SwarmCD..."
 	/app/swarm-cd
 else
-	$@
+	exec "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ else
     echo "entrypoint.sh: no gpg key found, skipping import"
 fi
 
-exec /app/swarm-cd "$@"
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,25 @@
 #!/bin/sh
 # Swarm-CD entrypoint, used to import gpg keys if needed
-if [ ! -z "${SOPS_GPG_PRIVATE_KEY}" ]; then
-    echo "entrypoint.sh: importing gpg private key..."
+if [ ! -z "${SOPS_GPG_PRIVATE_KEY_FILE}" ]; then
+    echo "entrypoint.sh: importing gpg private key from file..."
+
+    cat "${SOPS_GPG_PRIVATE_KEY_FILE}" | gpg --import
+
+    if [ $? -ne 0 ]; then
+        echo "entrypoint.sh: error: could not import GPG private key from file !"
+        exit 1
+    fi
+    echo "entrypoint.sh: gpg key imported from file successfully."
+elif [ ! -z "${SOPS_GPG_PRIVATE_KEY}" ]; then
+    echo "entrypoint.sh: importing gpg private key from environment..."
 
     echo "${SOPS_GPG_PRIVATE_KEY}" | gpg --import
     
     if [ $? -ne 0 ]; then
-        echo "entrypoint.sh: error: could not import GPG private key !"
+        echo "entrypoint.sh: error: could not import GPG private key from environment !"
         exit 1
     fi
-    echo "entrypoint.sh: gpg key imported successfully."
+    echo "entrypoint.sh: gpg key imported from environment successfully."
 else
     echo "entrypoint.sh: no gpg key found, skipping import"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Swarm-CD entrypoint, used to import gpg keys if needed
+if [ ! -z "${SOPS_GPG_PRIVATE_KEY}" ]; then
+    echo "entrypoint.sh: importing gpg private key..."
+
+    echo "${SOPS_GPG_PRIVATE_KEY}" | gpg --import
+    
+    if [ $? -ne 0 ]; then
+        echo "entrypoint.sh: error: could not import GPG private key !"
+        exit 1
+    fi
+    echo "entrypoint.sh: gpg key imported successfully."
+else
+    echo "entrypoint.sh: no gpg key found, skipping import"
+fi
+
+# Call the app
+if [ -z $@ ]; then
+    echo "entrypoint.sh: starting SwarmCD..."
+	/app/swarm-cd
+else
+	$@
+fi


### PR DESCRIPTION
Using an entrypoint, enables importing gpg key to the containers, to be used by sops for decryption.

Added gnupg to the container as well as basic documentation.

note: for now this only allows importing the private key from an environment variable; we could also support importing the key by mounting a key file on the container and passing a key file path as environment variable in the future if needed, which would be the same as for `age` :)