### PR TITLE
Apply AutoRotate to configs and secrets only when enabled

### DIFF
--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -75,10 +75,12 @@ func (swarmStack *swarmStack) updateStack() (revision string, err error) {
 		return "", fmt.Errorf("failed to decrypt one or more sops files for %s stack: %w", swarmStack.name, err)
 	}
 
-	log.Debug("rotating configs and secrets...")
-	err = swarmStack.rotateConfigsAndSecrets(stackContents)
-	if err != nil {
-		return
+	if config.AutoRotate {
+		log.Debug("rotating configs and secrets...")
+		err = swarmStack.rotateConfigsAndSecrets(stackContents)
+		if err != nil {
+			return
+		}
 	}
 
 	log.Debug("writing stack to file...")


### PR DESCRIPTION
Configs and secrets were being rotated regardless of the **auto_rotate** configuration flag.
This change wraps the rotation logic in a conditional check, ensuring rotation only occurs when it is enabled.