### PR TITLE
fix: add packages write permission to build jobs for fork compatibility

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -54,6 +54,8 @@ jobs:
     name: Build amd64
     needs: [test-go, test-node]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,6 +107,8 @@ jobs:
     name: Build arm64
     needs: [test-go, test-node]
     runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes https://github.com/m-adawi/swarm-cd/actions/runs/21799506396/job/62892604383

Permissions were missing for the build job