### PR TITLE
fix: limit concurrent deployments with configurable worker pool

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -4,6 +4,11 @@
 # waits everytime before pulling 
 update_interval: 120
 
+# The amount of parallel threads for deploying stacks.
+# The sensible value depends on the setup to prevent
+# the swarm manager from overloading.
+concurrency: 3
+
 # The path where SwarmCD will checkout repos
 repos_path: repos/
 

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,12 +1,13 @@
 # SwarmCD configuration file refernce
 
-# The interval in seconds that SwarmCD 
-# waits everytime before pulling 
+# The interval in seconds that SwarmCD
+# waits everytime before pulling
 update_interval: 120
 
 # The amount of parallel threads for deploying stacks.
 # The sensible value depends on the setup to prevent
 # the swarm manager from overloading.
+# NOTE: stacks on the same repo are NOT parallelized.
 concurrency: 3
 
 # The path where SwarmCD will checkout repos
@@ -20,11 +21,11 @@ sops_secrets_discovery: true
 # and secret names
 auto_rotate: true
 
-# You can define repos here instead of 
+# You can define repos here instead of
 # defining a separate repos.yaml file
 repos:
 
-# You can define stacks here instead of 
+# You can define stacks here instead of
 # defining a separate stacks.yaml file
 stacks:
 

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -6,31 +6,51 @@ import (
 	"time"
 )
 
-var stackStatus map[string]*StackStatus = map[string]*StackStatus{}
+var stackStatus = map[string]*StackStatus{}
 var stacks []*swarmStack
 
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {
+		logger.Debug("starting update loop")
 		var waitGroup sync.WaitGroup
-		logger.Info("updating stacks...")
-		for _, swarmStack := range stacks {
-			waitGroup.Add(1)
-			go updateStackThread(swarmStack, &waitGroup)
+		stacksChannel := make(chan *swarmStack, len(stacks))
+
+		// Start worker pool
+		logger.Debug(fmt.Sprintf("worker count: %v", config.Concurrency))
+		for range config.Concurrency {
+			go worker(stacksChannel, &waitGroup)
 		}
+
+		// Send stacks to workers
+		for _, swarmStack := range stacks {
+			logger.Debug(fmt.Sprintf("Queueing stack %v for update", swarmStack.name))
+			waitGroup.Add(1)
+			stacksChannel <- swarmStack
+		}
+		close(stacksChannel)
+
+		// Wait for all workers to complete
 		waitGroup.Wait()
+
 		logger.Info("waiting for the update interval")
 		time.Sleep(time.Duration(config.UpdateInterval) * time.Second)
 	}
 }
 
-func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
+func worker(stacks <-chan *swarmStack, waitGroup *sync.WaitGroup) {
+	for swarmStack := range stacks {
+		updateStackThread(swarmStack)
+		waitGroup.Done()
+	}
+}
+
+func updateStackThread(swarmStack *swarmStack) {
 	repoLock := swarmStack.repo.lock
 	repoLock.Lock()
 	defer repoLock.Unlock()
-	defer waitGroup.Done()
 
-	logger.Info(fmt.Sprintf("updating %s stack", swarmStack.name))
+	logger.Debug(fmt.Sprintf("%s checking if stack needs to be updated", swarmStack.name))
 	revision, err := swarmStack.updateStack()
 	if err != nil {
 		stackStatus[swarmStack.name].Error = err.Error()
@@ -40,7 +60,7 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 
 	stackStatus[swarmStack.name].Error = ""
 	stackStatus[swarmStack.name].Revision = revision
-	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
+	logger.Debug(fmt.Sprintf("%s stack updates check done", swarmStack.name))
 }
 
 func GetStackStatus() map[string]*StackStatus {

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -12,7 +12,7 @@ var stacks []*swarmStack
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {
-		logger.Debug("starting update loop")
+		logger.Info("starting update loop")
 		var waitGroup sync.WaitGroup
 		stacksChannel := make(chan *swarmStack, len(stacks))
 

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -17,14 +17,14 @@ func Run() {
 		stacksChannel := make(chan *swarmStack, len(stacks))
 
 		// Start worker pool
-		logger.Debug(fmt.Sprintf("worker count: %v", config.Concurrency))
+		logger.Debug(fmt.Sprintf("worker count: %d", config.Concurrency))
 		for range config.Concurrency {
 			go worker(stacksChannel, &waitGroup)
 		}
 
 		// Send stacks to workers
 		for _, swarmStack := range stacks {
-			logger.Debug(fmt.Sprintf("Queueing stack %v for update", swarmStack.name))
+			logger.Debug(fmt.Sprintf("Queueing stack %s for update", swarmStack.name))
 			waitGroup.Add(1)
 			stacksChannel <- swarmStack
 		}
@@ -38,8 +38,8 @@ func Run() {
 	}
 }
 
-func worker(stacks <-chan *swarmStack, waitGroup *sync.WaitGroup) {
-	for swarmStack := range stacks {
+func worker(workerStacks <-chan *swarmStack, waitGroup *sync.WaitGroup) {
+	for swarmStack := range workerStacks {
 		updateStackThread(swarmStack)
 		waitGroup.Done()
 	}
@@ -60,7 +60,7 @@ func updateStackThread(swarmStack *swarmStack) {
 
 	stackStatus[swarmStack.name].Error = ""
 	stackStatus[swarmStack.name].Revision = revision
-	logger.Debug(fmt.Sprintf("%s stack updates check done", swarmStack.name))
+	logger.Info(fmt.Sprintf("%s stack updates check done", swarmStack.name))
 }
 
 func GetStackStatus() map[string]*StackStatus {

--- a/util/config.go
+++ b/util/config.go
@@ -97,10 +97,9 @@ func readStackConfigs() (err error) {
 	return stacksViper.Unmarshal(&Configs.StackConfigs)
 }
 
-func validateConfig() error {
+func validateConfig() {
 	if Configs.Concurrency <= 0 {
-		Logger.Warn(fmt.Sprintf("Invalid `config.Concurrency value`, using default: %v", defaultWorkers))
+		Logger.Warn(fmt.Sprintf("Invalid `config.concurrency value`, using default: %v", defaultWorkers))
 		Configs.Concurrency = defaultWorkers
 	}
-	return nil
 }

--- a/util/config.go
+++ b/util/config.go
@@ -53,7 +53,8 @@ func LoadConfigs() (err error) {
 			return fmt.Errorf("could not load stacks file: %w", err)
 		}
 	}
-	return validateConfig()
+	validateConfig()
+	return nil
 }
 
 const defaultWorkers = 3


### PR DESCRIPTION
This is the first PR to bring the tremendous work made by @clangenb here
https://github.com/clangenb/swarm-cd/tree/develop

This is not the feature expected by most, but a needed fix before going further with new features.

- Add concurrency config option (default: 3 workers)
- Implement worker pool pattern for parallel stack deployments
- Workers pull from channel and process stacks concurrently
- Maintains thread safety with existing repo locks