### PR TITLE
feat: add image pull policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,34 @@ docker stack deploy --compose-file docker-compose.yaml swarm-cd
 This will start SwarmCD, it will periodically check the stack repo
 for new changes, pulling them and updating the stack.
 
+## Change Configuration directory location
+
+By default, SwarmCD looks for configuration files in the current working directory
+(`.`, that translates to `/app` in the docker container).  
+You can change this location by setting the `CONFIGS_PATH` environment variable.
+
+Using this, you can then specify a single folder in the `volumes` section.
+
+```yaml
+# docker-compose.yaml
+version: '3.7'
+services:
+  swarm-cd:
+    image: ghcr.io/m-adawi/swarm-cd:latest
+    deploy:
+      placement:
+        constraints:
+          - node.role == manager
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./configs:/app/configs:ro
+    environment:
+      - CONFIGS_PATH=/app/configs
+```
+
+> **NOTE:** due to how Docker Swarm works, it is better to use configs instead of bind mounts.
+  But if you only have a single manager node, it's OK to use this feature.
+
 ## Manage Encrypted Secrets Using SOPS
 
 You can use [sops](https://github.com/getsops/sops) to encrypt secrets in git repos and

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -21,6 +21,15 @@ sops_secrets_discovery: true
 # and secret names
 auto_rotate: true
 
+# Whether to always pull container images when deploying stacks.
+# When set to false (default), SwarmCD uses --resolve-image changed
+# which only pulls images when you change the tag in the stack file.
+# When set to true, SwarmCD uses --resolve-image always
+# which always queries the registry for images
+# and pulls new images if the SHA has changed.
+# This is a global default that can be overridden per-stack.
+always_pull_containers: false
+
 # You can define repos here instead of
 # defining a separate repos.yaml file
 repos:

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -22,13 +22,13 @@ sops_secrets_discovery: true
 auto_rotate: true
 
 # Whether to always pull container images when deploying stacks.
-# When set to false (default), SwarmCD uses --resolve-image changed
-# which only pulls images when you change the tag in the stack file.
-# When set to true, SwarmCD uses --resolve-image always
+# When set to true (default), SwarmCD uses `--resolve-image always`
 # which always queries the registry for images
 # and pulls new images if the SHA has changed.
+# When set to false, SwarmCD uses `--resolve-image changed`
+# which only pulls images when you change the tag in the stack file.
 # This is a global default that can be overridden per-stack.
-always_pull_containers: false
+always_pull_containers: true
 
 # You can define repos here instead of
 # defining a separate repos.yaml file

--- a/docs/repos.yaml
+++ b/docs/repos.yaml
@@ -1,5 +1,5 @@
-# SwarmCD repos configuration refernce 
-# Here you define the repos you want to 
+# SwarmCD repos configuration refernce
+# Here you define the repos you want to
 # deploy stacks from
 
 # The keys being repo names which should be
@@ -12,11 +12,9 @@ repo-name:
   username: user
   # Password or personal token
   password: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  # Recommended to use over `password`. 
+  # Recommended to use over `password`.
   # You can mount your password or token
   # to SwarmCD using docker secrets and
   # set this to the path of the password
   # file
   password_file: /path/to/password/file
-
-  

--- a/docs/stacks.yaml
+++ b/docs/stacks.yaml
@@ -1,8 +1,8 @@
-# SwarmCD stacks configuration refernce 
+# SwarmCD stacks configuration refernce
 # This file should contain all the stacks
-# that you want swarm-cd to keep synching 
+# that you want swarm-cd to keep synching
 
-# Name of the stack, it will be used in 
+# Name of the stack, it will be used in
 # the stack deploy command as the stack name
 stack-name:
   # The repo that contain the stack compose file
@@ -16,7 +16,7 @@ stack-name:
   compose_file: /path/to/compose.yaml
   # Path to values file to use when rendering
   # compose file as a Go template. If empty, compose
-  # file will be treated as a regular compose file 
+  # file will be treated as a regular compose file
   values_file: /path/to/values.yaml
   # Paths to files encrypted using sops to decrypt
   # before updating stack
@@ -25,3 +25,8 @@ stack-name:
   # Enable the automatic secret discovery
   # alternative to sops_files
   sops_secrets_discovery: false
+  # Override the global always_pull_containers setting
+  # for this specific stack. When not set, uses the global
+  # default. When set to true, always pulls new images.
+  # When set to false, only pulls when images tags change in the stack file.
+  always_pull_containers: false

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -97,8 +97,7 @@ func initStacks() error {
 		if !ok {
 			return fmt.Errorf("error initializing %s stack, no such repo: %s", stack, stackConfig.Repo)
 		}
-		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
-		swarmStack := newSwarmStack(stack, stackRepo, stackConfig.Branch, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+		swarmStack := newSwarmStackFromConfig(stack, stackRepo, stackConfig, config.SopsSecretsDiscovery)
 		stacks = append(stacks, swarmStack)
 		stackStatus[stack] = &StackStatus{}
 		stackStatus[stack].RepoURL = stackRepo.url

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -266,21 +266,10 @@ func (swarmStack *swarmStack) writeStack(composeMap map[string]any) error {
 }
 
 func (swarmStack *swarmStack) deployStack() error {
-	// Determine effective alwaysPullContainers value
-	// Stack-level override takes precedence, fallback to global setting
-	alwaysPull := config.AlwaysPullContainers
-	if swarmStack.alwaysPullContainers != nil {
-		alwaysPull = *swarmStack.alwaysPullContainers
-	}
-	resolveImage := "changed"
-	if alwaysPull {
-		resolveImage = "always"
-	}
-
 	cmd := stack.NewStackCommand(dockerCli)
 	cmd.SetArgs([]string{
 		"deploy", "--detach", "--with-registry-auth",
-		"--resolve-image", resolveImage,
+		"--resolve-image", swarmStack.resolveImageMode(),
 		"-c", path.Join(swarmStack.repo.path, swarmStack.composePath),
 		swarmStack.name,
 	})
@@ -293,4 +282,17 @@ func (swarmStack *swarmStack) deployStack() error {
 		return fmt.Errorf("could not deploy stack %s: %s", swarmStack.name, err)
 	}
 	return nil
+}
+
+func (swarmStack *swarmStack) resolveImageMode() string {
+	// Determine effective alwaysPullContainers value
+	// Stack-level override takes precedence, fallback to global setting
+	alwaysPull := config.AlwaysPullContainers
+	if swarmStack.alwaysPullContainers != nil {
+		alwaysPull = *swarmStack.alwaysPullContainers
+	}
+	if alwaysPull {
+		return "always"
+	}
+	return "changed"
 }

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -284,9 +284,9 @@ func (swarmStack *swarmStack) deployStack() error {
 	return nil
 }
 
+// Returns "always" when alwaysPullContainers is true, "changed" otherwise.
+// The stack-level setting overrides the global config setting.
 func (swarmStack *swarmStack) resolveImageMode() string {
-	// Determine effective alwaysPullContainers value
-	// Stack-level override takes precedence, fallback to global setting
 	alwaysPull := config.AlwaysPullContainers
 	if swarmStack.alwaysPullContainers != nil {
 		alwaysPull = *swarmStack.alwaysPullContainers

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -15,25 +15,40 @@ import (
 )
 
 type swarmStack struct {
-	name            string
-	repo            *stackRepo
-	branch          string
-	composePath     string
-	sopsFiles       []string
-	valuesFile      string
-	discoverSecrets bool
+	name                 string
+	repo                 *stackRepo
+	branch               string
+	composePath          string
+	sopsFiles            []string
+	valuesFile           string
+	discoverSecrets      bool
+	alwaysPullContainers *bool
 }
 
-func newSwarmStack(name string, repo *stackRepo, branch string, composePath string, sopsFiles []string, valuesFile string, discoverSecrets bool) *swarmStack {
+func newSwarmStack(name string, repo *stackRepo, branch string, composePath string, sopsFiles []string, valuesFile string, discoverSecrets bool, alwaysPullContainers *bool) *swarmStack {
 	return &swarmStack{
-		name:            name,
-		repo:            repo,
-		branch:          branch,
-		composePath:     composePath,
-		sopsFiles:       sopsFiles,
-		valuesFile:      valuesFile,
-		discoverSecrets: discoverSecrets,
+		name:                 name,
+		repo:                 repo,
+		branch:               branch,
+		composePath:          composePath,
+		sopsFiles:            sopsFiles,
+		valuesFile:           valuesFile,
+		discoverSecrets:      discoverSecrets,
+		alwaysPullContainers: alwaysPullContainers,
 	}
+}
+
+func newSwarmStackFromConfig(name string, repo *stackRepo, stackConfig *util.StackConfig, globalSecretsDiscovery bool) *swarmStack {
+	return newSwarmStack(
+		name,
+		repo,
+		stackConfig.Branch,
+		stackConfig.ComposeFile,
+		stackConfig.SopsFiles,
+		stackConfig.ValuesFile,
+		globalSecretsDiscovery || stackConfig.SopsSecretsDiscovery,
+		stackConfig.AlwaysPullContainers,
+	)
 }
 
 func (swarmStack *swarmStack) updateStack() (revision string, err error) {
@@ -251,10 +266,22 @@ func (swarmStack *swarmStack) writeStack(composeMap map[string]any) error {
 }
 
 func (swarmStack *swarmStack) deployStack() error {
+	// Determine effective alwaysPullContainers value
+	// Stack-level override takes precedence, fallback to global setting
+	alwaysPull := config.AlwaysPullContainers
+	if swarmStack.alwaysPullContainers != nil {
+		alwaysPull = *swarmStack.alwaysPullContainers
+	}
+	resolveImage := "changed"
+	if alwaysPull {
+		resolveImage = "always"
+	}
+
 	cmd := stack.NewStackCommand(dockerCli)
 	cmd.SetArgs([]string{
-		"deploy", "--detach", "--with-registry-auth", "-c",
-		path.Join(swarmStack.repo.path, swarmStack.composePath),
+		"deploy", "--detach", "--with-registry-auth",
+		"--resolve-image", resolveImage,
+		"-c", path.Join(swarmStack.repo.path, swarmStack.composePath),
 		swarmStack.name,
 	})
 	// To stop printing errors and

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -3,7 +3,49 @@ package swarmcd
 import (
 	"sync"
 	"testing"
+
+	"github.com/m-adawi/swarm-cd/util"
 )
+
+func boolPtr(v bool) *bool { return &v }
+
+// resolveImageMode returns "always" when alwaysPull is true, "changed" otherwise.
+// The stack-level setting overrides the global config setting.
+func TestResolveImageMode(t *testing.T) {
+	tests := []struct {
+		name           string
+		configPull     bool
+		stackPull      *bool
+		expectedResult string
+	}{
+		// Stack setting is unset: falls back to config
+		{"config=false stack=unset", false, nil, "changed"},
+		{"config=true  stack=unset", true, nil, "always"},
+		// Stack setting is explicit: overrides config in both directions
+		{"config=false stack=false", false, boolPtr(false), "changed"},
+		{"config=false stack=true", false, boolPtr(true), "always"},
+		{"config=true  stack=false", true, boolPtr(false), "changed"},
+		{"config=true  stack=true", true, boolPtr(true), "always"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Point the package-level config at a fresh Config value so
+			// parallel / sequential runs don't interfere with each other.
+			originalConfig := config
+			config = &util.Config{AlwaysPullContainers: tt.configPull}
+			t.Cleanup(func() { config = originalConfig })
+
+			repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+			s := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false, tt.stackPull)
+
+			got := s.resolveImageMode()
+			if got != tt.expectedResult {
+				t.Errorf("resolveImageMode() = %q, want %q", got, tt.expectedResult)
+			}
+		})
+	}
+}
 
 // Non-file objects are ignored by the rotation
 func TestRotateObjectsWithoutFile(t *testing.T) {

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -8,7 +8,7 @@ import (
 // Non-file objects are ignored by the rotation
 func TestRotateObjectsWithoutFile(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false, nil)
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 		"my-plugin-external-secret": map[string]any{
@@ -24,8 +24,13 @@ func TestRotateObjectsWithoutFile(t *testing.T) {
 // Secrets are discovered, external secrets are ignored
 func TestSecretDiscovery(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false)
-	stackString := []byte(`
+	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false, nil)
+	stackString := []byte(`services:
+  my-service:
+    image: my-image
+    secrets:
+      - my-secret
+      - my-external-secret
 secrets:
   my-secret:
     file: secrets/secret.yaml

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -9,8 +9,7 @@ import (
 
 func boolPtr(v bool) *bool { return &v }
 
-// resolveImageMode returns "always" when alwaysPull is true, "changed" otherwise.
-// The stack-level setting overrides the global config setting.
+// test all the possible combinations of config and stack AlwaysPullContainers settings.
 func TestResolveImageMode(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -18,10 +17,10 @@ func TestResolveImageMode(t *testing.T) {
 		stackPull      *bool
 		expectedResult string
 	}{
-		// Stack setting is unset: falls back to config
+		// Stack setting is unset: falls back to global config
 		{"config=false stack=unset", false, nil, "changed"},
 		{"config=true  stack=unset", true, nil, "always"},
-		// Stack setting is explicit: overrides config in both directions
+		// Stack setting is explicit: overrides global config
 		{"config=false stack=false", false, boolPtr(false), "changed"},
 		{"config=false stack=true", false, boolPtr(true), "always"},
 		{"config=true  stack=false", true, boolPtr(false), "changed"},

--- a/util/config.go
+++ b/util/config.go
@@ -80,7 +80,7 @@ func readConfig(path string) (err error) {
 	configViper.SetDefault("repos_path", "repos")
 	configViper.SetDefault("auto_rotate", true)
 	configViper.SetDefault("sops_secrets_discovery", false)
-	configViper.SetDefault("always_pull_containers", false)
+	configViper.SetDefault("always_pull_containers", true)
 	configViper.SetDefault("address", "0.0.0.0:8080")
 	err = configViper.ReadInConfig()
 	if err != nil && !errors.As(err, &viper.ConfigFileNotFoundError{}) {

--- a/util/config.go
+++ b/util/config.go
@@ -3,6 +3,7 @@ package util
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/viper"
 )
@@ -37,18 +38,20 @@ type Config struct {
 var Configs Config
 
 func LoadConfigs() (err error) {
-	err = readConfig()
+	configsPath := getConfigsPath()
+	Logger.Info(fmt.Sprintf("[Configs] path: %s", configsPath))
+	err = readConfig(configsPath)
 	if err != nil {
 		return fmt.Errorf("could not read configuration file: %w", err)
 	}
 	if Configs.RepoConfigs == nil {
-		err = readRepoConfigs()
+		err = readRepoConfigs(configsPath)
 		if err != nil {
 			return fmt.Errorf("could not read repos file: %w", err)
 		}
 	}
 	if Configs.StackConfigs == nil {
-		err = readStackConfigs()
+		err = readStackConfigs(configsPath)
 		if err != nil {
 			return fmt.Errorf("could not load stacks file: %w", err)
 		}
@@ -57,12 +60,19 @@ func LoadConfigs() (err error) {
 	return nil
 }
 
+func getConfigsPath() string {
+	if path := os.Getenv("CONFIGS_PATH"); path != "" {
+		return path
+	}
+	return "."
+}
+
 const defaultWorkers = 3
 
-func readConfig() (err error) {
+func readConfig(path string) (err error) {
 	configViper := viper.New()
 	configViper.SetConfigName("config")
-	configViper.AddConfigPath(".")
+	configViper.AddConfigPath(path)
 	configViper.SetDefault("update_interval", 120)
 	configViper.SetDefault("concurrency", defaultWorkers)
 	configViper.SetDefault("repos_path", "repos")
@@ -76,10 +86,10 @@ func readConfig() (err error) {
 	return configViper.Unmarshal(&Configs)
 }
 
-func readRepoConfigs() (err error) {
+func readRepoConfigs(path string) (err error) {
 	reposViper := viper.New()
 	reposViper.SetConfigName("repos")
-	reposViper.AddConfigPath(".")
+	reposViper.AddConfigPath(path)
 	err = reposViper.ReadInConfig()
 	if err != nil {
 		return
@@ -87,10 +97,10 @@ func readRepoConfigs() (err error) {
 	return reposViper.Unmarshal(&Configs.RepoConfigs)
 }
 
-func readStackConfigs() (err error) {
+func readStackConfigs(path string) (err error) {
 	stacksViper := viper.New()
 	stacksViper.SetConfigName("stacks")
-	stacksViper.AddConfigPath(".")
+	stacksViper.AddConfigPath(path)
 	err = stacksViper.ReadInConfig()
 	if err != nil {
 		return

--- a/util/config.go
+++ b/util/config.go
@@ -15,6 +15,7 @@ type StackConfig struct {
 	ValuesFile           string   `mapstructure:"values_file"`
 	SopsFiles            []string `mapstructure:"sops_files"`
 	SopsSecretsDiscovery bool     `mapstructure:"sops_secrets_discovery"`
+	AlwaysPullContainers *bool    `mapstructure:"always_pull_containers"`
 }
 
 type RepoConfig struct {
@@ -33,6 +34,7 @@ type Config struct {
 	RepoConfigs          map[string]*RepoConfig  `mapstructure:"repos"`
 	SopsSecretsDiscovery bool                    `mapstructure:"sops_secrets_discovery"`
 	Address              string                  `mapstructure:"address"`
+	AlwaysPullContainers bool                    `mapstructure:"always_pull_containers"`
 }
 
 var Configs Config
@@ -78,6 +80,7 @@ func readConfig(path string) (err error) {
 	configViper.SetDefault("repos_path", "repos")
 	configViper.SetDefault("auto_rotate", true)
 	configViper.SetDefault("sops_secrets_discovery", false)
+	configViper.SetDefault("always_pull_containers", false)
 	configViper.SetDefault("address", "0.0.0.0:8080")
 	err = configViper.ReadInConfig()
 	if err != nil && !errors.As(err, &viper.ConfigFileNotFoundError{}) {

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetConfigsPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		envSet   bool
+		want     string
+	}{
+		{
+			name:     "env var set with path",
+			envValue: "/custom/config/path",
+			envSet:   true,
+			want:     "/custom/config/path",
+		},
+		{
+			name:     "env var not set",
+			envValue: "",
+			envSet:   false,
+			want:     ".",
+		},
+		{
+			name:     "env var set to empty string",
+			envValue: "",
+			envSet:   true,
+			want:     ".",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up env var after test
+			originalValue, originalSet := os.LookupEnv("CONFIGS_PATH")
+			defer func() {
+				if originalSet {
+					os.Setenv("CONFIGS_PATH", originalValue)
+				} else {
+					os.Unsetenv("CONFIGS_PATH")
+				}
+			}()
+
+			if tt.envSet {
+				os.Setenv("CONFIGS_PATH", tt.envValue)
+			} else {
+				os.Unsetenv("CONFIGS_PATH")
+			}
+
+			if got := getConfigsPath(); got != tt.want {
+				t.Errorf("getConfigsPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This add a `always_pull_containers` global and per-stack option to choose if images should be pulled if the SHA256 changes (for example in the `latest` tag case).

The default is true, so it keeps the previous default behavior.
To save resources and unwanted re-deploys, users need to set this config to false.

Builds upon the other PRs just because I'm lazy :sweat_smile: 