### PR TITLE
fix: use transport.AuthMethod interface to support non-HTTP protocols

### DIFF
--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/m-adawi/swarm-cd/util"
 )
@@ -46,7 +47,7 @@ func Init() (err error) {
 func initRepos() error {
 	for repoName, repoConfig := range config.RepoConfigs {
 		repoPath := path.Join(config.ReposPath, repoName)
-		auth, err := createHTTPBasicAuth(repoName)
+		auth, err := createAuth(repoName)
 		if err != nil {
 			return err
 		}
@@ -58,9 +59,9 @@ func initRepos() error {
 	return nil
 }
 
-func createHTTPBasicAuth(repoName string) (*http.BasicAuth, error) {
+func createAuth(repoName string) (transport.AuthMethod, error) {
 	repoConfig := config.RepoConfigs[repoName]
-	// assume repo is public and no auth is required
+	// no credentials configured — public repo, no auth required
 	if repoConfig.Username == "" && repoConfig.Password == "" && repoConfig.PasswordFile == "" {
 		return nil, nil
 	}

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 type stackRepo struct {
@@ -16,11 +16,11 @@ type stackRepo struct {
 	lock          *sync.Mutex
 	url           string
 	gitRepoObject *git.Repository
-	auth          *http.BasicAuth
+	auth          transport.AuthMethod
 	path          string
 }
 
-func newStackRepo(name string, path string, url string, auth *http.BasicAuth) (*stackRepo, error) {
+func newStackRepo(name string, path string, url string, auth transport.AuthMethod) (*stackRepo, error) {
 	var repo *git.Repository
 	cloneOptions := &git.CloneOptions{
 		URL:  url,


### PR DESCRIPTION
## Summary

When no credentials are configured for a repository, `createHTTPBasicAuth()` returns a `nil` `*http.BasicAuth`. However, assigning this typed-nil pointer to the `transport.AuthMethod` interface (via `git.CloneOptions.Auth`) produces a **non-nil interface value**. This causes go-git to detect an HTTP auth method on non-HTTP transports and reject the operation with `invalid auth method`.

This affects any repo using `git://`, `ssh://`, or `file://` URLs without credentials.

## How to reproduce

1. Configure a repo with a `git://` URL and no credentials in `repos.yaml`:
   ```yaml
   my-repo:
     url: "git://myhost/repo.git"
   ```
2. SwarmCD fails with: `could not clone repo my-repo: invalid auth method`

After this fix, the clone succeeds as expected.

## Background

This is a well-known Go pitfall: https://go.dev/doc/faq#nil_error