### PR TITLE
feat: add support for ssh repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /swarm-cd ./cmd/
 FROM alpine:3.22.1
 WORKDIR /app
 
-RUN apk add --no-cache ca-certificates gnupg openssh-client && update-ca-certificates
+RUN apk add --no-cache ca-certificates gnupg && update-ca-certificates
 
 # Copy the built backend binary from the backend build stage
 COPY --from=backend-build /swarm-cd /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /swarm-cd ./cmd/
 # Stage 3: Final production image (depends on previous stages)
 FROM alpine:3.22.1
 WORKDIR /app
-
 RUN apk add --no-cache ca-certificates gnupg && update-ca-certificates
-
 # Copy the built backend binary from the backend build stage
 COPY --from=backend-build /swarm-cd /app/
 # Copy the built frontend from the frontend build stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /swarm-cd ./cmd/
 # Stage 3: Final production image (depends on previous stages)
 FROM alpine:3.22.1
 WORKDIR /app
-RUN apk add --no-cache ca-certificates gnupg && update-ca-certificates
+
+RUN apk add --no-cache ca-certificates gnupg openssh-client && update-ca-certificates
+
 # Copy the built backend binary from the backend build stage
 COPY --from=backend-build /swarm-cd /app/
 # Copy the built frontend from the frontend build stage

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -5,11 +5,9 @@ import (
 	"log/slog"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/m-adawi/swarm-cd/util"
 )
 
@@ -46,49 +44,16 @@ func Init() (err error) {
 func initRepos() error {
 	for repoName, repoConfig := range config.RepoConfigs {
 		repoPath := path.Join(config.ReposPath, repoName)
-		auth, err := createHTTPBasicAuth(repoName)
+		auth, err := createRepoAuth(repoName)
 		if err != nil {
 			return err
 		}
-		repos[repoName], err = newStackRepo(repoName, repoPath, repoConfig.Url, auth)
+		repos[repoName], err = newStackRepo(repoName, repoPath, repoConfig.Url, repoConfig.DefaultReference, auth)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func createHTTPBasicAuth(repoName string) (*http.BasicAuth, error) {
-	repoConfig := config.RepoConfigs[repoName]
-	// assume repo is public and no auth is required
-	if repoConfig.Username == "" && repoConfig.Password == "" && repoConfig.PasswordFile == "" {
-		return nil, nil
-	}
-
-	if repoConfig.Username == "" {
-		return nil, fmt.Errorf("you must set username for the repo %s", repoName)
-	}
-
-	if repoConfig.Password == "" && repoConfig.PasswordFile == "" {
-		return nil, fmt.Errorf("you must set one of password or password_file properties for the repo %s", repoName)
-	}
-
-	var password string
-	if repoConfig.Password != "" {
-		password = repoConfig.Password
-	} else {
-		passwordBytes, err := os.ReadFile(repoConfig.PasswordFile)
-		if err != nil {
-			return nil, fmt.Errorf("could not read password file %s for repo %s", repoConfig.PasswordFile, repoName)
-		}
-		// trim newline and whitespaces
-		password = strings.TrimSpace(string(passwordBytes))
-	}
-
-	return &http.BasicAuth{
-		Username: repoConfig.Username,
-		Password: password,
-	}, nil
 }
 
 func initStacks() error {

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -46,11 +46,11 @@ func initRepos() error {
 		repoPath := path.Join(config.ReposPath, repoName)
 		auth, err := createRepoAuth(repoName)
 		if err != nil {
-			return err
+			return fmt.Errorf("create auth for repo %q: %w", repoName, err)
 		}
 		repos[repoName], err = newStackRepo(repoName, repoPath, repoConfig.Url, repoConfig.DefaultReference, auth)
 		if err != nil {
-			return err
+			return fmt.Errorf("create stack repo %q: %w", repoName, err)
 		}
 	}
 	return nil

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 type stackRepo struct {
@@ -16,15 +16,16 @@ type stackRepo struct {
 	lock          *sync.Mutex
 	url           string
 	gitRepoObject *git.Repository
-	auth          *http.BasicAuth
+	auth          transport.AuthMethod
 	path          string
 }
 
-func newStackRepo(name string, path string, url string, auth *http.BasicAuth) (*stackRepo, error) {
+func newStackRepo(name, path, url, defaultReference string, auth transport.AuthMethod) (*stackRepo, error) {
 	var repo *git.Repository
 	cloneOptions := &git.CloneOptions{
-		URL:  url,
-		Auth: auth,
+		URL:           url,
+		Auth:          auth,
+		ReferenceName: plumbing.ReferenceName(defaultReference),
 	}
 	repo, err := git.PlainClone(path, false, cloneOptions)
 

--- a/swarmcd/repo_auth.go
+++ b/swarmcd/repo_auth.go
@@ -1,0 +1,63 @@
+package swarmcd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+func createRepoAuth(repoName string) (transport.AuthMethod, error) {
+	repoConfig := config.RepoConfigs[repoName]
+
+	if strings.HasPrefix(repoConfig.Url, "ssh://") {
+		return createSSHAuth(*repoConfig)
+	}
+
+	return createHTTPBasicAuth(repoName, *repoConfig)
+}
+
+func createSSHAuth(repoConfig util.RepoConfig) (transport.AuthMethod, error) {
+	username := repoConfig.Username
+	if username == "" {
+		username = "git"
+	}
+
+	return ssh.NewPublicKeysFromFile(repoConfig.Username, repoConfig.PasswordFile, "")
+}
+
+func createHTTPBasicAuth(repoName string, repoConfig util.RepoConfig) (*http.BasicAuth, error) {
+	// assume repo is public and no auth is required
+	if repoConfig.Username == "" && repoConfig.Password == "" && repoConfig.PasswordFile == "" {
+		return nil, nil
+	}
+
+	if repoConfig.Username == "" {
+		return nil, fmt.Errorf("you must set username for the repo %s", repoName)
+	}
+
+	if repoConfig.Password == "" && repoConfig.PasswordFile == "" {
+		return nil, fmt.Errorf("you must set one of password or password_file properties for the repo %s", repoName)
+	}
+
+	var password string
+	if repoConfig.Password != "" {
+		password = repoConfig.Password
+	} else {
+		passwordBytes, err := os.ReadFile(repoConfig.PasswordFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not read password file %s for repo %s", repoConfig.PasswordFile, repoName)
+		}
+		// trim newline and whitespaces
+		password = strings.TrimSpace(string(passwordBytes))
+	}
+
+	return &http.BasicAuth{
+		Username: repoConfig.Username,
+		Password: password,
+	}, nil
+}

--- a/swarmcd/repo_auth.go
+++ b/swarmcd/repo_auth.go
@@ -1,6 +1,7 @@
 package swarmcd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -18,7 +19,7 @@ func createRepoAuth(repoName string) (transport.AuthMethod, error) {
 		return createSSHAuth(*repoConfig)
 	}
 
-	return createHTTPBasicAuth(repoName, *repoConfig)
+	return createHTTPBasicAuth(*repoConfig)
 }
 
 func createSSHAuth(repoConfig util.RepoConfig) (transport.AuthMethod, error) {
@@ -27,37 +28,53 @@ func createSSHAuth(repoConfig util.RepoConfig) (transport.AuthMethod, error) {
 		username = "git"
 	}
 
-	return ssh.NewPublicKeysFromFile(repoConfig.Username, repoConfig.PasswordFile, "")
+	password, err := getPassword(repoConfig)
+	if err != nil {
+		return nil, fmt.Errorf("get password: %w", err)
+	}
+
+	return ssh.NewPublicKeysFromFile(repoConfig.Username, repoConfig.CertificateFile, password)
 }
 
-func createHTTPBasicAuth(repoName string, repoConfig util.RepoConfig) (*http.BasicAuth, error) {
+func createHTTPBasicAuth(repoConfig util.RepoConfig) (*http.BasicAuth, error) {
 	// assume repo is public and no auth is required
 	if repoConfig.Username == "" && repoConfig.Password == "" && repoConfig.PasswordFile == "" {
 		return nil, nil
 	}
 
 	if repoConfig.Username == "" {
-		return nil, fmt.Errorf("you must set username for the repo %s", repoName)
+		return nil, errors.New("you must set username for the repo")
 	}
 
 	if repoConfig.Password == "" && repoConfig.PasswordFile == "" {
-		return nil, fmt.Errorf("you must set one of password or password_file properties for the repo %s", repoName)
+		return nil, errors.New("you must set one of password or password_file properties for the repo")
 	}
 
-	var password string
-	if repoConfig.Password != "" {
-		password = repoConfig.Password
-	} else {
-		passwordBytes, err := os.ReadFile(repoConfig.PasswordFile)
-		if err != nil {
-			return nil, fmt.Errorf("could not read password file %s for repo %s", repoConfig.PasswordFile, repoName)
-		}
-		// trim newline and whitespaces
-		password = strings.TrimSpace(string(passwordBytes))
+	password, err := getPassword(repoConfig)
+	if err != nil {
+		return nil, fmt.Errorf("get password: %w", err)
 	}
 
 	return &http.BasicAuth{
 		Username: repoConfig.Username,
 		Password: password,
 	}, nil
+}
+
+func getPassword(repoConfig util.RepoConfig) (string, error) {
+	if repoConfig.Password == "" && repoConfig.PasswordFile == "" {
+		return "", nil
+	}
+
+	if repoConfig.Password != "" {
+		return repoConfig.Password, nil
+	}
+
+	passwordBytes, err := os.ReadFile(repoConfig.PasswordFile)
+	if err != nil {
+		return "", fmt.Errorf("could not read password file %q: %w", repoConfig.PasswordFile, err)
+	}
+
+	// trim newline and whitespaces
+	return strings.TrimSpace(string(passwordBytes)), nil
 }

--- a/util/config.go
+++ b/util/config.go
@@ -17,10 +17,11 @@ type StackConfig struct {
 }
 
 type RepoConfig struct {
-	Url          string
-	Username     string
-	Password     string
-	PasswordFile string `mapstructure:"password_file"`
+	Url              string
+	Username         string
+	Password         string
+	PasswordFile     string `mapstructure:"password_file"`
+	DefaultReference string `mapstructure:"default_reference"`
 }
 
 type Config struct {

--- a/util/config.go
+++ b/util/config.go
@@ -22,6 +22,7 @@ type RepoConfig struct {
 	Password         string
 	PasswordFile     string `mapstructure:"password_file"`
 	DefaultReference string `mapstructure:"default_reference"`
+	CertificateFile  string `mapstructure:"certificate_file"`
 }
 
 type Config struct {


### PR DESCRIPTION
Hi. 

This PR adds:
- Support for git repositories works over SSH. 
- Feature for set default reference of remote git repository like mirror

## repos.yaml for use SSH
```yaml
prod-infra:
  url: ssh://git@my-cloud-git.com/gitops.git
  certificate_file: /root/.ssh/ed25519
```

## repos.yaml for clone repository with branch
```yaml
prod-infra:
  url: ssh://git@my-cloud-git.com/gitops.git
  certificate_file: /root/.ssh/ed25519
  default_reference: refs/heads/master
```