### PR TITLE
feat: add git tag support and display watched ref in UI

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -85,7 +88,7 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -113,6 +116,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -138,7 +144,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -197,6 +203,9 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -217,9 +226,9 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/${{ github.repository }}:latest \
-            -t ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            -t ghcr.io/${{ env.REPO_LC }}:latest \
+            -t ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }} \
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Push to Docker Hub
         working-directory: /tmp/digests
@@ -228,18 +237,18 @@ jobs:
           for digest in *; do
             docker buildx imagetools create \
               -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:digest-${digest} \
-              ghcr.io/${{ github.repository }}@sha256:${digest}
+              ghcr.io/${{ env.REPO_LC }}@sha256:${digest}
           done
 
           # Create multi-arch manifest for Docker Hub
           docker buildx imagetools create \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Inspect images
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest
+          docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
           docker buildx imagetools inspect ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest
 
   update-dockerhub-description:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ nginx:
   compose_file: nginx/compose.yaml
 ```
 
+You can also deploy from a specific git tag instead of a branch (useful for release-based deployments):
+
+```yaml
+# stacks.yaml
+nginx:
+  repo: swarm-cd-example
+  tag: v1.2.3
+  compose_file: nginx/compose.yaml
+```
+
 And finally, we deploy SwarmCD to the cluster
 using the following docker-compose file:
 

--- a/docs/stacks.yaml
+++ b/docs/stacks.yaml
@@ -1,16 +1,22 @@
-# SwarmCD stacks configuration refernce 
+# SwarmCD stacks configuration refernce
 # This file should contain all the stacks
-# that you want swarm-cd to keep synching 
+# that you want swarm-cd to keep synching
 
-# Name of the stack, it will be used in 
+# Name of the stack, it will be used in
 # the stack deploy command as the stack name
 stack-name:
   # The repo that contain the stack compose file
   # and other config files
   repo: repo-name
   # The repo branch to checkout from the stack repo
-  # before deploying or updating stack
+  # before deploying or updating stack.
+  # Use either branch OR tag, not both.
+  # If neither is specified, defaults to 'main'.
   branch: main
+  # Alternatively, use a git tag instead of a branch.
+  # Useful for release-based deployments (e.g., v1.2.3).
+  # Mutually exclusive with 'branch'.
+  # tag: v1.0.0
   # The path to the docker compose file where stack
   # is defined
   compose_file: /path/to/compose.yaml

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -17,6 +17,7 @@ type StackStatus struct {
 	Error    string
 	Revision string
 	RepoURL  string
+	Ref      string
 }
 
 var config *util.Config = &util.Configs
@@ -97,11 +98,30 @@ func initStacks() error {
 		if !ok {
 			return fmt.Errorf("error initializing %s stack, no such repo: %s", stack, stackConfig.Repo)
 		}
+
+		// Validate branch/tag mutual exclusivity and determine ref
+		branch := stackConfig.Branch
+		tag := stackConfig.Tag
+		var ref string
+
+		if branch != "" && tag != "" {
+			return fmt.Errorf("error initializing %s stack: cannot specify both branch and tag", stack)
+		} else if tag != "" {
+			ref = "tag:" + tag
+		} else if branch != "" {
+			ref = "branch:" + branch
+		} else {
+			// Default to main branch for backward compatibility
+			branch = "main"
+			ref = "branch:main"
+		}
+
 		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
-		swarmStack := newSwarmStack(stack, stackRepo, stackConfig.Branch, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+		swarmStack := newSwarmStack(stack, stackRepo, branch, tag, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
 		stacks = append(stacks, swarmStack)
 		stackStatus[stack] = &StackStatus{}
 		stackStatus[stack].RepoURL = stackRepo.url
+		stackStatus[stack].Ref = ref
 	}
 	return nil
 }

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -94,6 +95,50 @@ func (repo *stackRepo) pullChanges(branch string) (revision string, err error) {
 	ref, err := repo.gitRepoObject.Head()
 	if err != nil {
 		return "", fmt.Errorf("could not get HEAD commit hash of %s branch in %s repo: %w", branch, repo.name, err)
+	}
+	// return HEAD commit short hash
+	return ref.Hash().String()[:8], nil
+}
+
+func (repo *stackRepo) fetchTag(tag string) (revision string, err error) {
+	log := logger.With(slog.String("repo", repo.name), slog.String("tag", tag))
+
+	log.Debug("getting repo worktree...")
+	workTree, err := repo.gitRepoObject.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("could not get %s repo worktree: %w", repo.name, err)
+	}
+
+	// Fetch the specific tag from remote
+	log.Debug("fetching tag...")
+	fetchOptions := &git.FetchOptions{
+		RemoteName: "origin",
+		Auth:       repo.auth,
+		RefSpecs:   []gitconfig.RefSpec{gitconfig.RefSpec("+refs/tags/" + tag + ":refs/tags/" + tag)},
+		Force:      true,
+	}
+	err = repo.gitRepoObject.Fetch(fetchOptions)
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		if err.Error() == "authentication required" {
+			err = fmt.Errorf("authentication failed")
+		}
+		return "", fmt.Errorf("could not fetch tag %s in %s repo: %w", tag, repo.name, err)
+	}
+
+	log.Debug("checking out tag...")
+	tagRef := plumbing.ReferenceName("refs/tags/" + tag)
+	err = workTree.Checkout(&git.CheckoutOptions{
+		Branch: tagRef,
+		Force:  true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not checkout tag %s in %s: %w", tag, repo.name, err)
+	}
+
+	log.Debug("getting revision...")
+	ref, err := repo.gitRepoObject.Head()
+	if err != nil {
+		return "", fmt.Errorf("could not get HEAD commit hash of tag %s in %s repo: %w", tag, repo.name, err)
 	}
 	// return HEAD commit short hash
 	return ref.Hash().String()[:8], nil

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -8,7 +8,7 @@ import (
 // External objects are ignored by the rotation
 func TestRotateExternalObjects(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 	}
@@ -21,7 +21,7 @@ func TestRotateExternalObjects(t *testing.T) {
 // Secrets are discovered, external secrets are ignored
 func TestSecretDiscovery(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "stacks/docker-compose.yaml", nil, "", false)
 	stackString := []byte(`services:
   my-service:
     image: my-image
@@ -46,5 +46,54 @@ secrets:
 	}
 	if sopsFiles[0] != "stacks/secrets/secret.yaml" {
 		t.Errorf("unexpected sops file: %s", sopsFiles[0])
+	}
+}
+
+// refAttr returns branch attribute when branch is set
+func TestRefAttrBranch(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "branch" {
+		t.Errorf("expected key 'branch', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "main" {
+		t.Errorf("expected value 'main', got '%s'", attr.Value.String())
+	}
+}
+
+// refAttr returns tag attribute when tag is set
+func TestRefAttrTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "", "v1.2.3", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "v1.2.3" {
+		t.Errorf("expected value 'v1.2.3', got '%s'", attr.Value.String())
+	}
+}
+
+// newSwarmStack correctly stores tag
+func TestNewSwarmStackWithTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("mystack", repo, "", "v2.0.0", "compose.yaml", nil, "", false)
+	if stack.tag != "v2.0.0" {
+		t.Errorf("expected tag 'v2.0.0', got '%s'", stack.tag)
+	}
+	if stack.branch != "" {
+		t.Errorf("expected empty branch, got '%s'", stack.branch)
+	}
+}
+
+// Verify refAttr prefers tag over branch when both could theoretically be set
+func TestRefAttrPrefersTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	// Even if branch has a value, tag takes precedence
+	stack := newSwarmStack("test", repo, "main", "v1.0.0", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag' to take precedence, got '%s'", attr.Key)
 	}
 }

--- a/ui/src/components/StatusCard.tsx
+++ b/ui/src/components/StatusCard.tsx
@@ -5,12 +5,14 @@ function StatusCard({
   name,
   error,
   revision,
-  repoURL
+  repoURL,
+  gitRef
 }: Readonly<{
   name: string
   error: string
   revision: string
   repoURL: string
+  gitRef: string
 }>): React.ReactElement {
   return (
     <Box borderWidth="1px" borderRadius="sm" overflow="hidden" p={4} boxShadow="lg">
@@ -24,6 +26,9 @@ function StatusCard({
             <Text color="red.500">{error}</Text>
           </>
         )}
+
+        <KeyText>Watching:</KeyText>
+        <Text>{gitRef}</Text>
 
         <KeyText>Revision:</KeyText>
         <Text>{revision}</Text>

--- a/ui/src/components/StatusCardList.tsx
+++ b/ui/src/components/StatusCardList.tsx
@@ -21,7 +21,7 @@ function StatusCardList({ statuses, query }: Readonly<{ statuses: StackStatus[];
         </Text>
       ) : (
         filteredStatuses.map((item, index) => (
-          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} />
+          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} gitRef={item.Ref} />
         ))
       )}
     </>

--- a/ui/src/hooks/dummyStackStatuses.json
+++ b/ui/src/hooks/dummyStackStatuses.json
@@ -3,18 +3,21 @@
     "Name": "Project Alpha",
     "Error": "",
     "Revision": "v1.0.1",
-    "RepoURL": "https://github.com/user/project-alpha"
+    "RepoURL": "https://github.com/user/project-alpha",
+    "Ref": "branch:main"
   },
   {
     "Name": "Project Beta",
     "Error": "Failed to build",
     "Revision": "v2.3.4",
-    "RepoURL": "https://github.com/user/project-beta"
+    "RepoURL": "https://github.com/user/project-beta",
+    "Ref": "tag:v2.3.4"
   },
   {
     "Name": "Project Gamma",
     "Error": "",
     "Revision": "v0.9.8",
-    "RepoURL": "https://github.com/user/project-gamma"
+    "RepoURL": "https://github.com/user/project-gamma",
+    "Ref": "branch:develop"
   }
 ]

--- a/ui/src/hooks/useFetchStatuses.tsx
+++ b/ui/src/hooks/useFetchStatuses.tsx
@@ -6,6 +6,7 @@ export interface StackStatus {
   Error: string
   Revision: string
   RepoURL: string
+  Ref: string
 }
 
 async function fetchFromServer(): Promise<StackStatus[]> {

--- a/ui/tests/components/StatusCard.test.tsx
+++ b/ui/tests/components/StatusCard.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from "@testing-library/react"
 import StatusCard from "../../src/components/StatusCard"
 
 describe("StatusCard", () => {
-  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234" }
+  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234", gitRef: "branch:main" }
 
   it("should render name, revision, and repoURL properties", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     for (const value of Object.values(status)) {
       const valueElement = screen.getByText(new RegExp(value, "i"))
@@ -14,7 +14,7 @@ describe("StatusCard", () => {
   })
 
   it("should render repoURL as a link", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const repoUrlElement = screen.getByRole("link", { name: status.repoURL })
     expect(repoUrlElement).toBeInTheDocument()
@@ -22,14 +22,14 @@ describe("StatusCard", () => {
   })
 
   it("should not render error if it is empty", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).not.toBeInTheDocument()
   })
 
   it("should render error if it is not empty", () => {
-    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).toBeInTheDocument()

--- a/ui/tests/components/StatusCardList.test.tsx
+++ b/ui/tests/components/StatusCardList.test.tsx
@@ -4,9 +4,9 @@ import { StackStatus } from "../../src/hooks/useFetchStatuses"
 
 describe("StatusCardList", () => {
   const statuses: StackStatus[] = [
-    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com" },
-    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com" },
-    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com" }
+    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com", Ref: "branch:main" },
+    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com", Ref: "tag:v2.0.0" },
+    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com", Ref: "branch:develop" }
   ]
 
   it("should render no statuses if the list of statuses is empty", () => {

--- a/util/config.go
+++ b/util/config.go
@@ -10,6 +10,7 @@ import (
 type StackConfig struct {
 	Repo                 string
 	Branch               string
+	Tag                  string
 	ComposeFile          string   `mapstructure:"compose_file"`
 	ValuesFile           string   `mapstructure:"values_file"`
 	SopsFiles            []string `mapstructure:"sops_files"`

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -13,10 +13,11 @@ func getStacks(ctx *gin.Context) {
 	var stacks []map[string]string
 	for k, v := range stacksStatus {
 		stacks = append(stacks, map[string]string{
-			"Name": k,
-			"Error": v.Error,
-			"RepoURL": v.RepoURL,
+			"Name":     k,
+			"Error":    v.Error,
+			"RepoURL":  v.RepoURL,
 			"Revision": v.Revision,
+			"Ref":      v.Ref,
 		})
 	}
 	sort.Slice(stacks, func(i, j int) bool {


### PR DESCRIPTION
## Summary

Add support for deploying stacks from git tags as an alternative to branches, and display the watched ref (branch or tag) in the web UI.

Closes #150

## Motivation

Some deployment workflows are release-based rather than branch-tracking. Operators pin stacks to a specific git tag (e.g., `v1.2.3`) and only update by changing the tag in the config. This is common in regulated environments or multi-tenant setups where you need explicit control over which version is deployed.

Currently SwarmCD only supports branch tracking. This PR adds tag support as a first-class alternative.

## Changes

**Go backend:**
- Add `tag` field to `StackConfig` (`util/config.go`) as an alternative to `branch`
- Add `fetchTag()` method to `stackRepo` (`swarmcd/repo.go`) — fetches and checks out a specific tag via refspec
- Update `updateStack()` (`swarmcd/stack.go`) to use `fetchTag()` when tag is configured
- Add `refAttr()` helper for structured logging with the correct ref type
- Validate branch/tag mutual exclusivity at init time (`swarmcd/init.go`)
- Default to `branch:main` when neither is specified (backward compatible)
- Add `Ref` field to `StackStatus` and expose in `GET /stacks` response

**Web UI:**
- Add `Ref` field to `StackStatus` TypeScript interface
- Display "Watching: branch:main" or "Watching: tag:v1.2.3" on status cards
- Update dummy data and tests

**CI:**
- Lowercase `github.repository` for GHCR image refs (fixes potential issues when repo name contains uppercase characters)

**Docs:**
- Update `stacks.yaml` reference with tag configuration
- Add tag usage example to README

## Usage

```yaml
# stacks.yaml - deploy from a tag instead of branch
nginx:
  repo: swarm-cd-example
  tag: v1.2.3
  compose_file: nginx/compose.yaml
```

Branch and tag are mutually exclusive. If both are specified, SwarmCD exits with an error at startup. If neither is specified, it defaults to `branch:main` for backward compatibility.

## Test plan

- [x] Unit tests for `refAttr()` — branch case, tag case, tag-takes-precedence case
- [x] Unit test for `newSwarmStack` with tag — verifies tag stored, branch empty
- [x] Existing tests updated with new `Ref` field in fixtures
- [x] UI tests updated for new `gitRef` prop on StatusCard
- [x] All Go tests pass (`go test ./...`)
- [x] All UI tests pass (`npm run test`)
