### PR TITLE
feat(web): extend read API with enhanced endpoints and config warnings

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -85,7 +88,7 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -113,6 +116,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -138,7 +144,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -197,6 +203,9 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -217,9 +226,9 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/${{ github.repository }}:latest \
-            -t ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            -t ghcr.io/${{ env.REPO_LC }}:latest \
+            -t ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }} \
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Push to Docker Hub
         working-directory: /tmp/digests
@@ -228,18 +237,18 @@ jobs:
           for digest in *; do
             docker buildx imagetools create \
               -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:digest-${digest} \
-              ghcr.io/${{ github.repository }}@sha256:${digest}
+              ghcr.io/${{ env.REPO_LC }}@sha256:${digest}
           done
 
           # Create multi-arch manifest for Docker Hub
           docker buildx imagetools create \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Inspect images
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest
+          docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
           docker buildx imagetools inspect ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest
 
   update-dockerhub-description:

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -59,6 +59,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        run: echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -85,7 +90,9 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64
+          build-args: VERSION=${{ env.VERSION }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
@@ -115,6 +122,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        run: echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -141,7 +153,9 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/arm64
+          build-args: VERSION=${{ env.VERSION }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 # Stage 2: Build the backend
 FROM golang:1.22-alpine AS backend-build
 ARG TARGETARCH
+ARG VERSION=dev
 WORKDIR /backend
 COPY go.mod go.sum ./
 RUN go mod download
@@ -16,7 +17,9 @@ COPY cmd/ cmd/
 COPY util/ util/
 COPY web/ web/
 COPY swarmcd/ swarmcd/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /swarm-cd ./cmd/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+      -ldflags "-X github.com/m-adawi/swarm-cd/swarmcd.Version=${VERSION}" \
+      -o /swarm-cd ./cmd/
 
 # Stage 3: Final production image (depends on previous stages)
 FROM alpine:3.22.1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ nginx:
   compose_file: nginx/compose.yaml
 ```
 
+You can also deploy from a specific git tag instead of a branch (useful for release-based deployments):
+
+```yaml
+# stacks.yaml
+nginx:
+  repo: swarm-cd-example
+  tag: v1.2.3
+  compose_file: nginx/compose.yaml
+```
+
 And finally, we deploy SwarmCD to the cluster
 using the following docker-compose file:
 

--- a/docs/stacks.yaml
+++ b/docs/stacks.yaml
@@ -1,16 +1,22 @@
-# SwarmCD stacks configuration refernce 
+# SwarmCD stacks configuration refernce
 # This file should contain all the stacks
-# that you want swarm-cd to keep synching 
+# that you want swarm-cd to keep synching
 
-# Name of the stack, it will be used in 
+# Name of the stack, it will be used in
 # the stack deploy command as the stack name
 stack-name:
   # The repo that contain the stack compose file
   # and other config files
   repo: repo-name
   # The repo branch to checkout from the stack repo
-  # before deploying or updating stack
+  # before deploying or updating stack.
+  # Use either branch OR tag, not both.
+  # If neither is specified, defaults to 'main'.
   branch: main
+  # Alternatively, use a git tag instead of a branch.
+  # Useful for release-based deployments (e.g., v1.2.3).
+  # Mutually exclusive with 'branch'.
+  # tag: v1.0.0
   # The path to the docker compose file where stack
   # is defined
   compose_file: /path/to/compose.yaml

--- a/swarmcd/concurrency_test.go
+++ b/swarmcd/concurrency_test.go
@@ -24,10 +24,12 @@ func TestConcurrentStatusRead(t *testing.T) {
 		name := fmt.Sprintf("test-stack-%d", i)
 		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 		repos[i] = repo
-		s := newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false)
+		s := newSwarmStack(name, repo, "main", "", "docker-compose.yaml", nil, "", false)
 		stacks = append(stacks, s)
 		stackStatus[name] = &StackStatus{
 			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 			Revision: "abc12345",
 		}
 	}
@@ -103,6 +105,8 @@ func TestGetStackStatusReturnsSnapshot(t *testing.T) {
 			Error:    "",
 			Revision: "aabb1122",
 			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 		},
 	}
 	stacks = nil
@@ -149,9 +153,11 @@ func TestLockOrderingNoDeadlock(t *testing.T) {
 		name := fmt.Sprintf("deadlock-test-%d", i)
 		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 		repos[i] = repo
-		stacks = append(stacks, newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false))
+		stacks = append(stacks, newSwarmStack(name, repo, "main", "", "docker-compose.yaml", nil, "", false))
 		stackStatus[name] = &StackStatus{
-			RepoURL: "http://example.com",
+			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 		}
 	}
 	stateMu.Unlock()

--- a/swarmcd/concurrency_test.go
+++ b/swarmcd/concurrency_test.go
@@ -1,0 +1,200 @@
+package swarmcd
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestConcurrentStatusRead spawns N goroutines reading GetStackStatus() while
+// reconciliation-style goroutines write to stackStatus. This test is designed
+// to be run with -race to detect data races.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestConcurrentStatusRead(t *testing.T) {
+	// Set up test state: populate stackStatus and stacks with test data
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{}
+	stacks = nil
+
+	const numStacks = 5
+	repos := make([]*stackRepo, numStacks)
+	for i := 0; i < numStacks; i++ {
+		name := fmt.Sprintf("test-stack-%d", i)
+		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+		repos[i] = repo
+		s := newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false)
+		stacks = append(stacks, s)
+		stackStatus[name] = &StackStatus{
+			RepoURL:  "http://example.com",
+			Revision: "abc12345",
+		}
+	}
+	stateMu.Unlock()
+
+	// Restore original state when done
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	var wg sync.WaitGroup
+	const numReaders = 10
+	const numWriters = 5
+	const iterations = 100
+
+	// Start reader goroutines that call GetStackStatus() concurrently
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				status := GetStackStatus()
+				// Access the returned snapshot to ensure it's a real copy
+				for k, v := range status {
+					_ = k
+					_ = v.Error
+					_ = v.Revision
+					_ = v.RepoURL
+				}
+			}
+		}()
+	}
+
+	// Start writer goroutines that simulate reconciliation writes
+	// These follow the correct lock ordering: repo.lock first, then stateMu
+	for i := 0; i < numWriters; i++ {
+		stackIdx := i % numStacks
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("test-stack-%d", idx)
+			repo := repos[idx]
+			for j := 0; j < iterations; j++ {
+				// Simulate lock ordering: acquire repo.lock, do work, release, then acquire stateMu
+				repo.lock.Lock()
+				// Simulate some work under repo lock
+				revision := fmt.Sprintf("%08x", j)
+				repo.lock.Unlock()
+
+				stateMu.Lock()
+				stackStatus[name].Revision = revision
+				stackStatus[name].Error = ""
+				stateMu.Unlock()
+			}
+		}(stackIdx)
+	}
+
+	wg.Wait()
+}
+
+// TestGetStackStatusReturnsSnapshot verifies that GetStackStatus returns a
+// copy so mutations to the returned map don't affect the original.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestGetStackStatusReturnsSnapshot(t *testing.T) {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{
+		"snap-test": {
+			Error:    "",
+			Revision: "aabb1122",
+			RepoURL:  "http://example.com",
+		},
+	}
+	stacks = nil
+	stateMu.Unlock()
+
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	snapshot := GetStackStatus()
+
+	// Mutate the snapshot
+	snapshot["snap-test"].Revision = "MUTATED"
+	snapshot["extra"] = &StackStatus{Revision: "bogus"}
+
+	// Verify original is unchanged
+	stateMu.RLock()
+	if stackStatus["snap-test"].Revision != "aabb1122" {
+		t.Errorf("original stackStatus was mutated: got revision %q, want %q", stackStatus["snap-test"].Revision, "aabb1122")
+	}
+	if _, exists := stackStatus["extra"]; exists {
+		t.Error("original stackStatus should not contain 'extra' key")
+	}
+	stateMu.RUnlock()
+}
+
+// TestLockOrderingNoDeadlock verifies that the lock ordering (release repo.lock
+// before acquiring stateMu) does not cause deadlock when multiple goroutines
+// follow the pattern simultaneously.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestLockOrderingNoDeadlock(t *testing.T) {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{}
+	stacks = nil
+
+	const numStacks = 3
+	repos := make([]*stackRepo, numStacks)
+	for i := 0; i < numStacks; i++ {
+		name := fmt.Sprintf("deadlock-test-%d", i)
+		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+		repos[i] = repo
+		stacks = append(stacks, newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false))
+		stackStatus[name] = &StackStatus{
+			RepoURL: "http://example.com",
+		}
+	}
+	stateMu.Unlock()
+
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	var wg sync.WaitGroup
+
+	// Simulate multiple reconciliation goroutines with correct lock ordering
+	for i := 0; i < numStacks; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("deadlock-test-%d", idx)
+			repo := repos[idx]
+			for j := 0; j < 50; j++ {
+				// Correct ordering: repo.lock then release, then stateMu
+				repo.lock.Lock()
+				revision := fmt.Sprintf("%08x", j)
+				repo.lock.Unlock()
+
+				stateMu.Lock()
+				stackStatus[name].Revision = revision
+				stateMu.Unlock()
+			}
+		}(i)
+	}
+
+	// Concurrent readers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = GetStackStatus()
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -17,6 +17,7 @@ type StackStatus struct {
 	Error    string
 	Revision string
 	RepoURL  string
+	Ref      string
 }
 
 var config *util.Config = &util.Configs
@@ -97,11 +98,30 @@ func initStacks() error {
 		if !ok {
 			return fmt.Errorf("error initializing %s stack, no such repo: %s", stack, stackConfig.Repo)
 		}
+
+		// Validate branch/tag mutual exclusivity and determine ref
+		branch := stackConfig.Branch
+		tag := stackConfig.Tag
+		var ref string
+
+		if branch != "" && tag != "" {
+			return fmt.Errorf("error initializing %s stack: cannot specify both branch and tag", stack)
+		} else if tag != "" {
+			ref = "tag:" + tag
+		} else if branch != "" {
+			ref = "branch:" + branch
+		} else {
+			// Default to main branch for backward compatibility
+			branch = "main"
+			ref = "branch:main"
+		}
+
 		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
-		swarmStack := newSwarmStack(stack, stackRepo, stackConfig.Branch, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+		swarmStack := newSwarmStack(stack, stackRepo, branch, tag, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
 		stacks = append(stacks, swarmStack)
 		stackStatus[stack] = &StackStatus{}
 		stackStatus[stack].RepoURL = stackRepo.url
+		stackStatus[stack].Ref = ref
 	}
 	return nil
 }

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
@@ -14,11 +15,27 @@ import (
 )
 
 type StackStatus struct {
-	Error    string
-	Revision string
-	RepoURL  string
-	Ref      string
+	Error          string
+	Revision       string
+	RepoURL        string
+	RefType        string
+	RefValue       string
+	ComposeFile    string
+	LastChangeAt   *time.Time
+	LastDeployedAt *time.Time
 }
+
+// RuntimeInfo holds instance-level metadata set at startup.
+type RuntimeInfo struct {
+	BootedAt time.Time
+	Version  string
+}
+
+// Version is the application version, overridden at build time via
+// -ldflags "-X github.com/m-adawi/swarm-cd/swarmcd.Version=..."
+var Version = "dev"
+
+var runtimeInfo RuntimeInfo
 
 var config *util.Config = &util.Configs
 
@@ -29,6 +46,11 @@ var repos map[string]*stackRepo = map[string]*stackRepo{}
 var dockerCli *command.DockerCli
 
 func Init() (err error) {
+	runtimeInfo = RuntimeInfo{
+		BootedAt: time.Now(),
+		Version:  Version,
+	}
+
 	err = initRepos()
 	if err != nil {
 		return err
@@ -102,26 +124,35 @@ func initStacks() error {
 		// Validate branch/tag mutual exclusivity and determine ref
 		branch := stackConfig.Branch
 		tag := stackConfig.Tag
-		var ref string
+		var refType, refValue string
 
 		if branch != "" && tag != "" {
 			return fmt.Errorf("error initializing %s stack: cannot specify both branch and tag", stack)
 		} else if tag != "" {
-			ref = "tag:" + tag
+			refType = "tag"
+			refValue = tag
 		} else if branch != "" {
-			ref = "branch:" + branch
+			refType = "branch"
+			refValue = branch
 		} else {
 			// Default to main branch for backward compatibility
 			branch = "main"
-			ref = "branch:main"
+			refType = "branch"
+			refValue = "main"
 		}
 
 		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
 		swarmStack := newSwarmStack(stack, stackRepo, branch, tag, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+
+		stateMu.Lock()
 		stacks = append(stacks, swarmStack)
-		stackStatus[stack] = &StackStatus{}
-		stackStatus[stack].RepoURL = stackRepo.url
-		stackStatus[stack].Ref = ref
+		stackStatus[stack] = &StackStatus{
+			RepoURL:     stackRepo.url,
+			RefType:     refType,
+			RefValue:    refValue,
+			ComposeFile: stackConfig.ComposeFile,
+		}
+		stateMu.Unlock()
 	}
 	return nil
 }

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -94,6 +95,50 @@ func (repo *stackRepo) pullChanges(branch string) (revision string, err error) {
 	ref, err := repo.gitRepoObject.Head()
 	if err != nil {
 		return "", fmt.Errorf("could not get HEAD commit hash of %s branch in %s repo: %w", branch, repo.name, err)
+	}
+	// return HEAD commit short hash
+	return ref.Hash().String()[:8], nil
+}
+
+func (repo *stackRepo) fetchTag(tag string) (revision string, err error) {
+	log := logger.With(slog.String("repo", repo.name), slog.String("tag", tag))
+
+	log.Debug("getting repo worktree...")
+	workTree, err := repo.gitRepoObject.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("could not get %s repo worktree: %w", repo.name, err)
+	}
+
+	// Fetch the specific tag from remote
+	log.Debug("fetching tag...")
+	fetchOptions := &git.FetchOptions{
+		RemoteName: "origin",
+		Auth:       repo.auth,
+		RefSpecs:   []gitconfig.RefSpec{gitconfig.RefSpec("+refs/tags/" + tag + ":refs/tags/" + tag)},
+		Force:      true,
+	}
+	err = repo.gitRepoObject.Fetch(fetchOptions)
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		if err.Error() == "authentication required" {
+			err = fmt.Errorf("authentication failed")
+		}
+		return "", fmt.Errorf("could not fetch tag %s in %s repo: %w", tag, repo.name, err)
+	}
+
+	log.Debug("checking out tag...")
+	tagRef := plumbing.ReferenceName("refs/tags/" + tag)
+	err = workTree.Checkout(&git.CheckoutOptions{
+		Branch: tagRef,
+		Force:  true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not checkout tag %s in %s: %w", tag, repo.name, err)
+	}
+
+	log.Debug("getting revision...")
+	ref, err := repo.gitRepoObject.Head()
+	if err != nil {
+		return "", fmt.Errorf("could not get HEAD commit hash of tag %s in %s repo: %w", tag, repo.name, err)
 	}
 	// return HEAD commit short hash
 	return ref.Hash().String()[:8], nil

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -8,7 +8,7 @@ import (
 // External objects are ignored by the rotation
 func TestRotateExternalObjects(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 	}
@@ -21,7 +21,7 @@ func TestRotateExternalObjects(t *testing.T) {
 // Secrets are discovered, external secrets are ignored
 func TestSecretDiscovery(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "stacks/docker-compose.yaml", nil, "", false)
 	stackString := []byte(`services:
   my-service:
     image: my-image
@@ -46,5 +46,54 @@ secrets:
 	}
 	if sopsFiles[0] != "stacks/secrets/secret.yaml" {
 		t.Errorf("unexpected sops file: %s", sopsFiles[0])
+	}
+}
+
+// refAttr returns branch attribute when branch is set
+func TestRefAttrBranch(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "branch" {
+		t.Errorf("expected key 'branch', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "main" {
+		t.Errorf("expected value 'main', got '%s'", attr.Value.String())
+	}
+}
+
+// refAttr returns tag attribute when tag is set
+func TestRefAttrTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "", "v1.2.3", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "v1.2.3" {
+		t.Errorf("expected value 'v1.2.3', got '%s'", attr.Value.String())
+	}
+}
+
+// newSwarmStack correctly stores tag
+func TestNewSwarmStackWithTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("mystack", repo, "", "v2.0.0", "compose.yaml", nil, "", false)
+	if stack.tag != "v2.0.0" {
+		t.Errorf("expected tag 'v2.0.0', got '%s'", stack.tag)
+	}
+	if stack.branch != "" {
+		t.Errorf("expected empty branch, got '%s'", stack.branch)
+	}
+}
+
+// Verify refAttr prefers tag over branch when both could theoretically be set
+func TestRefAttrPrefersTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	// Even if branch has a value, tag takes precedence
+	stack := newSwarmStack("test", repo, "main", "v1.0.0", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag' to take precedence, got '%s'", attr.Key)
 	}
 }

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -9,12 +9,21 @@ import (
 var stackStatus map[string]*StackStatus = map[string]*StackStatus{}
 var stacks []*swarmStack
 
+// stateMu protects stackStatus and stacks from concurrent access.
+// Lock ordering: stateMu must never be acquired while repo.lock is held.
+// Acquiring stateMu independently (without any repo.lock) is always safe.
+var stateMu sync.RWMutex
+
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {
 		var waitGroup sync.WaitGroup
 		logger.Info("updating stacks...")
-		for _, swarmStack := range stacks {
+		stateMu.RLock()
+		currentStacks := make([]*swarmStack, len(stacks))
+		copy(currentStacks, stacks)
+		stateMu.RUnlock()
+		for _, swarmStack := range currentStacks {
 			waitGroup.Add(1)
 			go updateStackThread(swarmStack, &waitGroup)
 		}
@@ -25,24 +34,42 @@ func Run() {
 }
 
 func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
-	repoLock := swarmStack.repo.lock
-	repoLock.Lock()
-	defer repoLock.Unlock()
 	defer waitGroup.Done()
 
+	repoLock := swarmStack.repo.lock
+	repoLock.Lock()
 	logger.Info(fmt.Sprintf("updating %s stack", swarmStack.name))
 	revision, err := swarmStack.updateStack()
+	repoLock.Unlock() // Release repo.lock BEFORE acquiring stateMu
+
+	stateMu.Lock()
+	status := stackStatus[swarmStack.name]
 	if err != nil {
-		stackStatus[swarmStack.name].Error = err.Error()
+		status.Error = err.Error()
+	} else {
+		status.Error = ""
+		status.Revision = revision
+	}
+	stateMu.Unlock()
+
+	if err != nil {
 		logger.Error(err.Error())
 		return
 	}
-
-	stackStatus[swarmStack.name].Error = ""
-	stackStatus[swarmStack.name].Revision = revision
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }
 
+// GetStackStatus returns a snapshot of all stack statuses under a read lock.
+// The returned map is a copy — callers cannot mutate the original values.
+// StackStatus currently contains only value types (strings); update this
+// copy logic if pointer or slice fields are added.
 func GetStackStatus() map[string]*StackStatus {
-	return stackStatus
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	snapshot := make(map[string]*StackStatus, len(stackStatus))
+	for k, v := range stackStatus {
+		cp := *v
+		snapshot[k] = &cp
+	}
+	return snapshot
 }

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -42,13 +42,20 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	revision, err := swarmStack.updateStack()
 	repoLock.Unlock() // Release repo.lock BEFORE acquiring stateMu
 
+	now := time.Now()
+
 	stateMu.Lock()
 	status := stackStatus[swarmStack.name]
 	if err != nil {
 		status.Error = err.Error()
 	} else {
+		// Set LastChangeAt when the revision changes
+		if revision != status.Revision {
+			status.LastChangeAt = &now
+		}
 		status.Error = ""
 		status.Revision = revision
+		status.LastDeployedAt = &now
 	}
 	stateMu.Unlock()
 
@@ -59,16 +66,32 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }
 
+// GetRuntimeInfo returns a copy of the instance's runtime metadata.
+// Protected by stateMu for consistency, though in practice runtimeInfo
+// is only written once during Init() before Run() starts.
+func GetRuntimeInfo() RuntimeInfo {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return runtimeInfo
+}
+
 // GetStackStatus returns a snapshot of all stack statuses under a read lock.
-// The returned map is a copy — callers cannot mutate the original values.
-// StackStatus currently contains only value types (strings); update this
-// copy logic if pointer or slice fields are added.
+// Pointer fields (LastChangeAt, LastDeployedAt) are deep-copied so callers
+// cannot mutate the original values.
 func GetStackStatus() map[string]*StackStatus {
 	stateMu.RLock()
 	defer stateMu.RUnlock()
 	snapshot := make(map[string]*StackStatus, len(stackStatus))
 	for k, v := range stackStatus {
 		cp := *v
+		if v.LastChangeAt != nil {
+			t := *v.LastChangeAt
+			cp.LastChangeAt = &t
+		}
+		if v.LastDeployedAt != nil {
+			t := *v.LastDeployedAt
+			cp.LastDeployedAt = &t
+		}
 		snapshot[k] = &cp
 	}
 	return snapshot

--- a/swarmcd/test_helpers.go
+++ b/swarmcd/test_helpers.go
@@ -1,0 +1,138 @@
+// test_helpers.go lives in the swarmcd package (not a _test.go file) so that
+// test files in other packages (e.g., web/) can call these helpers to safely
+// swap internal state. This is intentional — SwarmCD is a standalone binary,
+// not a library, so the exported surface area is not a concern.
+package swarmcd
+
+import (
+	"sync"
+
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+// SetStackStatusForTest replaces the internal stackStatus map with the given
+// test data and returns a cleanup function that restores the original state.
+// This is intended for use in tests only.
+func SetStackStatusForTest(testStatus map[string]*StackStatus) func() {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = testStatus
+	stacks = nil
+	stateMu.Unlock()
+
+	return func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}
+}
+
+// SetRuntimeInfoForTest replaces the internal runtimeInfo with the given
+// test data and returns a cleanup function that restores the original state.
+// This is intended for use in tests only.
+func SetRuntimeInfoForTest(info RuntimeInfo) func() {
+	stateMu.Lock()
+	old := runtimeInfo
+	runtimeInfo = info
+	stateMu.Unlock()
+	return func() {
+		stateMu.Lock()
+		runtimeInfo = old
+		stateMu.Unlock()
+	}
+}
+
+// TestStackDef describes a stack for test setup purposes.
+type TestStackDef struct {
+	Name        string
+	RepoName    string
+	RepoPath    string
+	RepoURL     string
+	Branch      string
+	Tag         string
+	ComposeFile string
+}
+
+// SetFullStateForTest builds and replaces all internal state (stackStatus,
+// stacks, repos, and util.Configs) from the given definitions. Returns a
+// cleanup function that restores the original state.
+func SetFullStateForTest(defs []TestStackDef) func() {
+	oldRepoConfigs := config.RepoConfigs
+	oldStackConfigs := config.StackConfigs
+
+	newStatus := make(map[string]*StackStatus)
+	newRepos := make(map[string]*stackRepo)
+	newRepoCfgs := make(map[string]*util.RepoConfig)
+	newStackCfgs := make(map[string]*util.StackConfig)
+	var newStacks []*swarmStack
+
+	for _, d := range defs {
+		// Create repo if not already created
+		if _, ok := newRepos[d.RepoName]; !ok {
+			newRepos[d.RepoName] = &stackRepo{
+				name:          d.RepoName,
+				path:          d.RepoPath,
+				url:           d.RepoURL,
+				auth:          nil,
+				lock:          &sync.Mutex{},
+				gitRepoObject: nil,
+			}
+			newRepoCfgs[d.RepoName] = &util.RepoConfig{Url: d.RepoURL}
+		}
+
+		repo := newRepos[d.RepoName]
+
+		var refType, refValue string
+		if d.Tag != "" {
+			refType = "tag"
+			refValue = d.Tag
+		} else if d.Branch != "" {
+			refType = "branch"
+			refValue = d.Branch
+		} else {
+			refType = "branch"
+			refValue = "main"
+		}
+
+		newStatus[d.Name] = &StackStatus{
+			RepoURL:     d.RepoURL,
+			RefType:     refType,
+			RefValue:    refValue,
+			ComposeFile: d.ComposeFile,
+		}
+
+		newStackCfgs[d.Name] = &util.StackConfig{
+			Repo:        d.RepoName,
+			Branch:      d.Branch,
+			Tag:         d.Tag,
+			ComposeFile: d.ComposeFile,
+		}
+
+		s := newSwarmStack(d.Name, repo, d.Branch, d.Tag, d.ComposeFile, nil, "", false)
+		newStacks = append(newStacks, s)
+	}
+
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	oldRepos := repos
+	stackStatus = newStatus
+	stacks = newStacks
+	repos = newRepos
+	stateMu.Unlock()
+
+	config.RepoConfigs = newRepoCfgs
+	config.StackConfigs = newStackCfgs
+
+	return func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		repos = oldRepos
+		stateMu.Unlock()
+		config.RepoConfigs = oldRepoConfigs
+		config.StackConfigs = oldStackConfigs
+	}
+}

--- a/ui/src/components/StatusCard.tsx
+++ b/ui/src/components/StatusCard.tsx
@@ -5,12 +5,14 @@ function StatusCard({
   name,
   error,
   revision,
-  repoURL
+  repoURL,
+  gitRef
 }: Readonly<{
   name: string
   error: string
   revision: string
   repoURL: string
+  gitRef: string
 }>): React.ReactElement {
   return (
     <Box borderWidth="1px" borderRadius="sm" overflow="hidden" p={4} boxShadow="lg">
@@ -24,6 +26,9 @@ function StatusCard({
             <Text color="red.500">{error}</Text>
           </>
         )}
+
+        <KeyText>Watching:</KeyText>
+        <Text>{gitRef}</Text>
 
         <KeyText>Revision:</KeyText>
         <Text>{revision}</Text>

--- a/ui/src/components/StatusCardList.tsx
+++ b/ui/src/components/StatusCardList.tsx
@@ -21,7 +21,7 @@ function StatusCardList({ statuses, query }: Readonly<{ statuses: StackStatus[];
         </Text>
       ) : (
         filteredStatuses.map((item, index) => (
-          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} />
+          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} gitRef={item.Ref} />
         ))
       )}
     </>

--- a/ui/src/hooks/dummyStackStatuses.json
+++ b/ui/src/hooks/dummyStackStatuses.json
@@ -3,18 +3,21 @@
     "Name": "Project Alpha",
     "Error": "",
     "Revision": "v1.0.1",
-    "RepoURL": "https://github.com/user/project-alpha"
+    "RepoURL": "https://github.com/user/project-alpha",
+    "Ref": "branch:main"
   },
   {
     "Name": "Project Beta",
     "Error": "Failed to build",
     "Revision": "v2.3.4",
-    "RepoURL": "https://github.com/user/project-beta"
+    "RepoURL": "https://github.com/user/project-beta",
+    "Ref": "tag:v2.3.4"
   },
   {
     "Name": "Project Gamma",
     "Error": "",
     "Revision": "v0.9.8",
-    "RepoURL": "https://github.com/user/project-gamma"
+    "RepoURL": "https://github.com/user/project-gamma",
+    "Ref": "branch:develop"
   }
 ]

--- a/ui/src/hooks/useFetchStatuses.tsx
+++ b/ui/src/hooks/useFetchStatuses.tsx
@@ -6,6 +6,7 @@ export interface StackStatus {
   Error: string
   Revision: string
   RepoURL: string
+  Ref: string
 }
 
 async function fetchFromServer(): Promise<StackStatus[]> {

--- a/ui/tests/components/StatusCard.test.tsx
+++ b/ui/tests/components/StatusCard.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from "@testing-library/react"
 import StatusCard from "../../src/components/StatusCard"
 
 describe("StatusCard", () => {
-  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234" }
+  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234", gitRef: "branch:main" }
 
   it("should render name, revision, and repoURL properties", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     for (const value of Object.values(status)) {
       const valueElement = screen.getByText(new RegExp(value, "i"))
@@ -14,7 +14,7 @@ describe("StatusCard", () => {
   })
 
   it("should render repoURL as a link", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const repoUrlElement = screen.getByRole("link", { name: status.repoURL })
     expect(repoUrlElement).toBeInTheDocument()
@@ -22,14 +22,14 @@ describe("StatusCard", () => {
   })
 
   it("should not render error if it is empty", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).not.toBeInTheDocument()
   })
 
   it("should render error if it is not empty", () => {
-    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).toBeInTheDocument()

--- a/ui/tests/components/StatusCardList.test.tsx
+++ b/ui/tests/components/StatusCardList.test.tsx
@@ -4,9 +4,9 @@ import { StackStatus } from "../../src/hooks/useFetchStatuses"
 
 describe("StatusCardList", () => {
   const statuses: StackStatus[] = [
-    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com" },
-    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com" },
-    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com" }
+    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com", Ref: "branch:main" },
+    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com", Ref: "tag:v2.0.0" },
+    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com", Ref: "branch:develop" }
   ]
 
   it("should render no statuses if the list of statuses is empty", () => {

--- a/util/config.go
+++ b/util/config.go
@@ -10,6 +10,7 @@ import (
 type StackConfig struct {
 	Repo                 string
 	Branch               string
+	Tag                  string
 	ComposeFile          string   `mapstructure:"compose_file"`
 	ValuesFile           string   `mapstructure:"values_file"`
 	SopsFiles            []string `mapstructure:"sops_files"`

--- a/util/config.go
+++ b/util/config.go
@@ -3,9 +3,25 @@ package util
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/spf13/viper"
 )
+
+// ConfigConflict records whether stacks/repos are defined inline in
+// config.yaml (which prevents API persistence from working) and whether
+// the corresponding split files also exist on disk.
+type ConfigConflict struct {
+	StacksInline     bool
+	ReposInline      bool
+	StacksFileExists bool
+	ReposFileExists  bool
+}
+
+// Conflict is populated during LoadConfigs and reflects the inline vs.
+// split-file state detected at startup.
+var Conflict ConfigConflict
 
 type StackConfig struct {
 	Repo                 string
@@ -41,6 +57,10 @@ func LoadConfigs() (err error) {
 	if err != nil {
 		return fmt.Errorf("could not read configuration file: %w", err)
 	}
+
+	// Detect inline config conflicts and check for split files on disk.
+	Conflict = detectConflicts()
+
 	if Configs.RepoConfigs == nil {
 		err = readRepoConfigs()
 		if err != nil {
@@ -53,7 +73,65 @@ func LoadConfigs() (err error) {
 			return fmt.Errorf("could not load stacks file: %w", err)
 		}
 	}
+
+	// Emit startup log warnings for detected conflicts.
+	logConfigWarnings(Logger)
+
 	return
+}
+
+// detectConflicts checks whether stacks/repos were loaded inline from
+// config.yaml and whether the corresponding split files exist on disk.
+func detectConflicts() ConfigConflict {
+	c := ConfigConflict{
+		StacksInline: Configs.StackConfigs != nil,
+		ReposInline:  Configs.RepoConfigs != nil,
+	}
+	if _, err := os.Stat("stacks.yaml"); err == nil {
+		c.StacksFileExists = true
+	}
+	if _, err := os.Stat("repos.yaml"); err == nil {
+		c.ReposFileExists = true
+	}
+	return c
+}
+
+// ConfigWarnings returns human-readable warning strings based on the
+// current ConfigConflict state. The returned slice is empty when no
+// conflicts exist.
+func ConfigWarnings() []string {
+	return configWarnings(Conflict)
+}
+
+func configWarnings(c ConfigConflict) []string {
+	var warnings []string
+
+	if c.StacksInline {
+		if c.StacksFileExists {
+			warnings = append(warnings, "stacks.yaml is ignored because stacks are defined in config.yaml")
+		} else {
+			warnings = append(warnings, "API changes to stacks won't persist across restarts")
+		}
+	}
+
+	if c.ReposInline {
+		if c.ReposFileExists {
+			warnings = append(warnings, "repos.yaml is ignored because repos are defined in config.yaml")
+		} else {
+			warnings = append(warnings, "API changes to repos won't persist across restarts")
+		}
+	}
+
+	return warnings
+}
+
+func logConfigWarnings(log *slog.Logger) {
+	if log == nil {
+		return
+	}
+	for _, w := range ConfigWarnings() {
+		log.Warn(w)
+	}
 }
 
 func readConfig() (err error) {

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,280 @@
+package util
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------- Config conflict detection tests ----------
+
+// TestConfigConflict_InlineStacksNoFile verifies that when stacks are
+// defined inline in config.yaml and no stacks.yaml exists on disk,
+// the conflict is detected and the "won't persist" warning is emitted.
+func TestConfigConflict_InlineStacksNoFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+stacks:
+  my-stack:
+    repo: my-repo
+    branch: main
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.StacksInline {
+		t.Error("expected StacksInline=true")
+	}
+	if Conflict.StacksFileExists {
+		t.Error("expected StacksFileExists=false")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "API changes to stacks won't persist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'won't persist' warning for stacks, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineStacksWithFile verifies that when stacks are
+// defined inline in config.yaml AND stacks.yaml also exists on disk,
+// the "ignored" warning is emitted.
+func TestConfigConflict_InlineStacksWithFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+stacks:
+  my-stack:
+    repo: my-repo
+    branch: main
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("other-stack:\n  repo: other\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.StacksInline {
+		t.Error("expected StacksInline=true")
+	}
+	if !Conflict.StacksFileExists {
+		t.Error("expected StacksFileExists=true")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "stacks.yaml is ignored") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'stacks.yaml is ignored' warning, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_SplitOnly verifies that when stacks are only in
+// stacks.yaml (not inline), no conflict is detected.
+func TestConfigConflict_SplitOnly(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+update_interval: 60
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com/repo\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if Conflict.StacksInline {
+		t.Error("expected StacksInline=false")
+	}
+	if Conflict.ReposInline {
+		t.Error("expected ReposInline=false")
+	}
+
+	warnings := ConfigWarnings()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for split-only config, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineReposNoFile verifies that when repos are
+// defined inline in config.yaml and no repos.yaml exists on disk,
+// the "won't persist" warning is emitted.
+func TestConfigConflict_InlineReposNoFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+repos:
+  my-repo:
+    url: https://example.com/repo
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.ReposInline {
+		t.Error("expected ReposInline=true")
+	}
+	if Conflict.ReposFileExists {
+		t.Error("expected ReposFileExists=false")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "API changes to repos won't persist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'won't persist' warning for repos, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineReposWithFile verifies that when repos are
+// defined inline AND repos.yaml exists, the "ignored" warning is emitted.
+func TestConfigConflict_InlineReposWithFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+repos:
+  my-repo:
+    url: https://example.com/repo
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("other-repo:\n  url: https://other.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.ReposInline {
+		t.Error("expected ReposInline=true")
+	}
+	if !Conflict.ReposFileExists {
+		t.Error("expected ReposFileExists=true")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "repos.yaml is ignored") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'repos.yaml is ignored' warning, got %v", warnings)
+	}
+}

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -13,10 +13,11 @@ func getStacks(ctx *gin.Context) {
 	var stacks []map[string]string
 	for k, v := range stacksStatus {
 		stacks = append(stacks, map[string]string{
-			"Name": k,
-			"Error": v.Error,
-			"RepoURL": v.RepoURL,
+			"Name":     k,
+			"Error":    v.Error,
+			"RepoURL":  v.RepoURL,
 			"Revision": v.Revision,
+			"Ref":      v.Ref,
 		})
 	}
 	sort.Slice(stacks, func(i, j int) bool {

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -1,27 +1,91 @@
 package web
 
 import (
+	"fmt"
+	"math"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/m-adawi/swarm-cd/swarmcd"
+	"github.com/m-adawi/swarm-cd/util"
 )
+
+type stackResponse struct {
+	Name           string     `json:"name"`
+	RepoURL        string     `json:"repo_url"`
+	RefType        string     `json:"ref_type"`
+	RefValue       string     `json:"ref_value"`
+	Revision       string     `json:"revision"`
+	ComposeFile    string     `json:"compose_file"`
+	Error          string     `json:"error"`
+	LastChangeAt   *time.Time `json:"last_change_at"`
+	LastDeployedAt *time.Time `json:"last_deployed_at"`
+}
+
+func getHealth(ctx *gin.Context) {
+	info := swarmcd.GetRuntimeInfo()
+	stacksStatus := swarmcd.GetStackStatus()
+	uptime := time.Since(info.BootedAt).Seconds()
+
+	resp := gin.H{
+		"status":                  "healthy",
+		"booted_at":               info.BootedAt,
+		"version":                 info.Version,
+		"uptime_seconds":          math.Floor(uptime),
+		"update_interval_seconds": util.Configs.UpdateInterval,
+		"stacks_managed":          len(stacksStatus),
+	}
+
+	if warnings := util.ConfigWarnings(); len(warnings) > 0 {
+		resp["config_warnings"] = warnings
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}
+
+func getStack(ctx *gin.Context) {
+	name := ctx.Param("name")
+	stacksStatus := swarmcd.GetStackStatus()
+	v, ok := stacksStatus[name]
+	if !ok {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("stack '%s' not found", name),
+		})
+		return
+	}
+	ctx.JSON(http.StatusOK, stackResponse{
+		Name:           name,
+		RepoURL:        v.RepoURL,
+		RefType:        v.RefType,
+		RefValue:       v.RefValue,
+		Revision:       v.Revision,
+		ComposeFile:    v.ComposeFile,
+		Error:          v.Error,
+		LastChangeAt:   v.LastChangeAt,
+		LastDeployedAt: v.LastDeployedAt,
+	})
+}
 
 func getStacks(ctx *gin.Context) {
 	stacksStatus := swarmcd.GetStackStatus()
-	var stacks []map[string]string
+	var stacks []stackResponse
 	for k, v := range stacksStatus {
-		stacks = append(stacks, map[string]string{
-			"Name":     k,
-			"Error":    v.Error,
-			"RepoURL":  v.RepoURL,
-			"Revision": v.Revision,
-			"Ref":      v.Ref,
+		stacks = append(stacks, stackResponse{
+			Name:           k,
+			RepoURL:        v.RepoURL,
+			RefType:        v.RefType,
+			RefValue:       v.RefValue,
+			Revision:       v.Revision,
+			ComposeFile:    v.ComposeFile,
+			Error:          v.Error,
+			LastChangeAt:   v.LastChangeAt,
+			LastDeployedAt: v.LastDeployedAt,
 		})
 	}
 	sort.Slice(stacks, func(i, j int) bool {
-		return stacks[i]["Name"] < stacks[j]["Name"]
+		return stacks[i].Name < stacks[j].Name
 	})
 	ctx.JSON(http.StatusOK, stacks)
 }

--- a/web/controllers_test.go
+++ b/web/controllers_test.go
@@ -1,0 +1,466 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/m-adawi/swarm-cd/swarmcd"
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+// setupTestStacks populates the swarmcd package-level state with test data
+// and returns a cleanup function to restore the original state.
+func setupTestStacks(t *testing.T, data map[string]*swarmcd.StackStatus) func() {
+	t.Helper()
+	return swarmcd.SetStackStatusForTest(data)
+}
+
+// decodeBody is a test helper that decodes a JSON response body into a map.
+func decodeBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	return body
+}
+
+func TestGetStacks_ReturnsAllFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().Truncate(time.Second)
+	earlier := now.Add(-1 * time.Hour)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"my-stack": {
+			Error:          "some error",
+			Revision:       "abc12345",
+			RepoURL:        "https://github.com/example/repo",
+			RefType:        "branch",
+			RefValue:       "main",
+			ComposeFile:    "docker-compose.yaml",
+			LastChangeAt:   &earlier,
+			LastDeployedAt: &now,
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks", getStacks)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var stacks []stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &stacks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+
+	s := stacks[0]
+
+	if s.Name != "my-stack" {
+		t.Errorf("expected name %q, got %q", "my-stack", s.Name)
+	}
+	if s.RepoURL != "https://github.com/example/repo" {
+		t.Errorf("expected repo_url %q, got %q", "https://github.com/example/repo", s.RepoURL)
+	}
+	if s.RefType != "branch" {
+		t.Errorf("expected ref_type %q, got %q", "branch", s.RefType)
+	}
+	if s.RefValue != "main" {
+		t.Errorf("expected ref_value %q, got %q", "main", s.RefValue)
+	}
+	if s.Revision != "abc12345" {
+		t.Errorf("expected revision %q, got %q", "abc12345", s.Revision)
+	}
+	if s.ComposeFile != "docker-compose.yaml" {
+		t.Errorf("expected compose_file %q, got %q", "docker-compose.yaml", s.ComposeFile)
+	}
+	if s.Error != "some error" {
+		t.Errorf("expected error %q, got %q", "some error", s.Error)
+	}
+	if s.LastChangeAt == nil {
+		t.Fatal("expected last_change_at to be non-nil")
+	}
+	if !s.LastChangeAt.Equal(earlier) {
+		t.Errorf("expected last_change_at %v, got %v", earlier, *s.LastChangeAt)
+	}
+	if s.LastDeployedAt == nil {
+		t.Fatal("expected last_deployed_at to be non-nil")
+	}
+	if !s.LastDeployedAt.Equal(now) {
+		t.Errorf("expected last_deployed_at %v, got %v", now, *s.LastDeployedAt)
+	}
+
+	// Verify JSON field names are snake_case by checking raw JSON
+	var raw []map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("failed to decode raw response: %v", err)
+	}
+	expectedKeys := []string{"name", "repo_url", "ref_type", "ref_value", "revision", "compose_file", "error", "last_change_at", "last_deployed_at"}
+	for _, key := range expectedKeys {
+		if _, ok := raw[0][key]; !ok {
+			t.Errorf("expected JSON key %q not found in response", key)
+		}
+	}
+}
+
+func TestGetStacks_SortOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"charlie": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "main",
+		},
+		"alpha": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "tag",
+			RefValue: "v1.0.0",
+		},
+		"bravo": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "develop",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks", getStacks)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var stacks []stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &stacks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(stacks) != 3 {
+		t.Fatalf("expected 3 stacks, got %d", len(stacks))
+	}
+
+	expectedOrder := []string{"alpha", "bravo", "charlie"}
+	for i, expected := range expectedOrder {
+		if stacks[i].Name != expected {
+			t.Errorf("position %d: expected %q, got %q", i, expected, stacks[i].Name)
+		}
+	}
+}
+
+// ---------- GET /stacks/:name tests ----------
+
+func TestGetStackByName_Found(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().Truncate(time.Second)
+	earlier := now.Add(-1 * time.Hour)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"my-stack": {
+			Error:          "",
+			Revision:       "abc12345",
+			RepoURL:        "https://github.com/example/repo",
+			RefType:        "branch",
+			RefValue:       "main",
+			ComposeFile:    "docker-compose.yaml",
+			LastChangeAt:   &earlier,
+			LastDeployedAt: &now,
+		},
+		"other-stack": {
+			Revision: "def67890",
+			RepoURL:  "https://github.com/example/other",
+			RefType:  "tag",
+			RefValue: "v1.0.0",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks/:name", getStack)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks/my-stack", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var s stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if s.Name != "my-stack" {
+		t.Errorf("expected name %q, got %q", "my-stack", s.Name)
+	}
+	if s.RepoURL != "https://github.com/example/repo" {
+		t.Errorf("expected repo_url %q, got %q", "https://github.com/example/repo", s.RepoURL)
+	}
+	if s.RefType != "branch" {
+		t.Errorf("expected ref_type %q, got %q", "branch", s.RefType)
+	}
+	if s.RefValue != "main" {
+		t.Errorf("expected ref_value %q, got %q", "main", s.RefValue)
+	}
+}
+
+func TestGetStackByName_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"existing-stack": {
+			Revision: "abc12345",
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "main",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks/:name", getStack)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks/foo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	expected := "stack 'foo' not found"
+	if body["error"] != expected {
+		t.Errorf("expected error %q, got %q", expected, body["error"])
+	}
+}
+
+// ---------- GET /health tests ----------
+
+func TestGetHealth_ReturnsBootTime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if body["status"] != "healthy" {
+		t.Errorf("expected status %q, got %q", "healthy", body["status"])
+	}
+
+	// Verify booted_at is present and parseable
+	bootedAtStr, ok := body["booted_at"].(string)
+	if !ok {
+		t.Fatalf("expected booted_at to be a string, got %T", body["booted_at"])
+	}
+	parsedBoot, err := time.Parse(time.RFC3339Nano, bootedAtStr)
+	if err != nil {
+		t.Fatalf("failed to parse booted_at %q: %v", bootedAtStr, err)
+	}
+	if !parsedBoot.Equal(bootedAt) {
+		t.Errorf("expected booted_at %v, got %v", bootedAt, parsedBoot)
+	}
+
+	// Verify uptime is positive
+	uptimeRaw, ok := body["uptime_seconds"].(float64)
+	if !ok {
+		t.Fatalf("expected uptime_seconds to be a number, got %T", body["uptime_seconds"])
+	}
+	if uptimeRaw <= 0 {
+		t.Errorf("expected positive uptime_seconds, got %v", uptimeRaw)
+	}
+
+	if body["version"] != "dev" {
+		t.Errorf("expected version %q, got %q", "dev", body["version"])
+	}
+
+	if body["update_interval_seconds"] != float64(120) {
+		t.Errorf("expected update_interval_seconds=120, got %v", body["update_interval_seconds"])
+	}
+}
+
+func TestGetHealth_ReturnsStackCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "1.2.3",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"stack-a": {Revision: "aaa", RepoURL: "https://github.com/a"},
+		"stack-b": {Revision: "bbb", RepoURL: "https://github.com/b"},
+		"stack-c": {Revision: "ccc", RepoURL: "https://github.com/c"},
+	})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 60
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if body["stacks_managed"] != float64(3) {
+		t.Errorf("expected stacks_managed=3, got %v", body["stacks_managed"])
+	}
+
+	if body["version"] != "1.2.3" {
+		t.Errorf("expected version %q, got %q", "1.2.3", body["version"])
+	}
+}
+
+// ---------- GET /health config_warnings tests ----------
+
+func TestGetHealth_ReturnsConfigWarnings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	// Simulate inline config conflict (stacks inline, no split file)
+	oldConflict := util.Conflict
+	util.Conflict = util.ConfigConflict{
+		StacksInline:     true,
+		ReposInline:      false,
+		StacksFileExists: false,
+		ReposFileExists:  false,
+	}
+	defer func() { util.Conflict = oldConflict }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	rawWarnings, ok := body["config_warnings"]
+	if !ok {
+		t.Fatal("expected config_warnings key in health response")
+	}
+	warnings, ok := rawWarnings.([]interface{})
+	if !ok {
+		t.Fatalf("expected config_warnings to be an array, got %T", rawWarnings)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if warnings[0] != "API changes to stacks won't persist across restarts" {
+		t.Errorf("unexpected warning: %v", warnings[0])
+	}
+}
+
+func TestGetHealth_NoConfigWarnings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	// No conflicts — split config only
+	oldConflict := util.Conflict
+	util.Conflict = util.ConfigConflict{}
+	defer func() { util.Conflict = oldConflict }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if _, ok := body["config_warnings"]; ok {
+		t.Error("expected no config_warnings key when there are no conflicts")
+	}
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -12,6 +12,8 @@ var router *gin.Engine = gin.New()
 func init() {
 	router.Use(sloggin.New(util.Logger))
 	router.GET("/stacks", getStacks)
+	router.GET("/stacks/:name", getStack)
+	router.GET("/health", getHealth)
 	router.StaticFile("/ui", "ui/index.html")
 	router.Static("/assets", "ui/assets")
 	router.GET("/", func(c *gin.Context) {


### PR DESCRIPTION
## Summary

- Enhanced `GET /stacks` — typed response with snake_case fields, timestamps, split `ref_type`/`ref_value`
- New `GET /stacks/{name}` — single-stack lookup with 404 handling
- Enhanced `GET /health` — boot time, uptime, version, stacks managed, config warnings
- Config conflict detection — warns when inline `config.yaml` shadows split files (`stacks.yaml`/`repos.yaml`)
- Shared test infrastructure for cross-package testing
- Version injection via `-ldflags` at build time (Dockerfile + CI)

## Dependencies

- **#156** (concurrency fix) — must be merged first
- **#149** (tag support) — `ref_type`/`ref_value` distinction requires branch/tag awareness

This PR includes both dependencies in its branch so it compiles and tests pass. Once #156 and #149 are merged, this PR can be rebased cleanly onto main.

## Test Results

- 22 Go tests pass (including `-race`)
- 13 UI tests pass (unchanged)
- 5 new config conflict detection tests
- 8 new web endpoint tests

*Part of the REST API proposal discussed in #151.*

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)