### PR TITLE
feat(web): add write API — auth, PATCH, restart, config persistence

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -85,7 +88,7 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -113,6 +116,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -138,7 +144,7 @@ jobs:
           platforms: linux/arm64
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
-          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
+          outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
 
       - name: Export digest
         if: ${{ github.ref_name == 'main' }}
@@ -197,6 +203,9 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
 
+      - name: Set lowercase repo name
+        run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -217,9 +226,9 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            -t ghcr.io/${{ github.repository }}:latest \
-            -t ghcr.io/${{ github.repository }}:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            -t ghcr.io/${{ env.REPO_LC }}:latest \
+            -t ghcr.io/${{ env.REPO_LC }}:${{ needs.release.outputs.new_release_version }} \
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Push to Docker Hub
         working-directory: /tmp/digests
@@ -228,18 +237,18 @@ jobs:
           for digest in *; do
             docker buildx imagetools create \
               -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:digest-${digest} \
-              ghcr.io/${{ github.repository }}@sha256:${digest}
+              ghcr.io/${{ env.REPO_LC }}@sha256:${digest}
           done
 
           # Create multi-arch manifest for Docker Hub
           docker buildx imagetools create \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest \
             -t ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:${{ needs.release.outputs.new_release_version }} \
-            $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+            $(printf 'ghcr.io/${{ env.REPO_LC }}@sha256:%s ' *)
 
       - name: Inspect images
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest
+          docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:latest
           docker buildx imagetools inspect ${{ vars.DOCKERHUB_USERNAME }}/swarm-cd:latest
 
   update-dockerhub-description:

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -59,6 +59,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        run: echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -85,7 +90,9 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/amd64
+          build-args: VERSION=${{ env.VERSION }}
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}
@@ -115,6 +122,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        run: echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
 
       - name: Set lowercase repo name
         run: echo "REPO_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
@@ -141,7 +153,9 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: linux/arm64
+          build-args: VERSION=${{ env.VERSION }}
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
           outputs: type=image,name=ghcr.io/${{ env.REPO_LC }},push-by-digest=true,name-canonical=true,push=${{ github.ref_name == 'main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm run build
 # Stage 2: Build the backend
 FROM golang:1.22-alpine AS backend-build
 ARG TARGETARCH
+ARG VERSION=dev
 WORKDIR /backend
 COPY go.mod go.sum ./
 RUN go mod download
@@ -16,7 +17,9 @@ COPY cmd/ cmd/
 COPY util/ util/
 COPY web/ web/
 COPY swarmcd/ swarmcd/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -o /swarm-cd ./cmd/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+      -ldflags "-X github.com/m-adawi/swarm-cd/swarmcd.Version=${VERSION}" \
+      -o /swarm-cd ./cmd/
 
 # Stage 3: Final production image (depends on previous stages)
 FROM alpine:3.22.1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ nginx:
   compose_file: nginx/compose.yaml
 ```
 
+You can also deploy from a specific git tag instead of a branch (useful for release-based deployments):
+
+```yaml
+# stacks.yaml
+nginx:
+  repo: swarm-cd-example
+  tag: v1.2.3
+  compose_file: nginx/compose.yaml
+```
+
 And finally, we deploy SwarmCD to the cluster
 using the following docker-compose file:
 

--- a/docs/stacks.yaml
+++ b/docs/stacks.yaml
@@ -1,16 +1,22 @@
-# SwarmCD stacks configuration refernce 
+# SwarmCD stacks configuration refernce
 # This file should contain all the stacks
-# that you want swarm-cd to keep synching 
+# that you want swarm-cd to keep synching
 
-# Name of the stack, it will be used in 
+# Name of the stack, it will be used in
 # the stack deploy command as the stack name
 stack-name:
   # The repo that contain the stack compose file
   # and other config files
   repo: repo-name
   # The repo branch to checkout from the stack repo
-  # before deploying or updating stack
+  # before deploying or updating stack.
+  # Use either branch OR tag, not both.
+  # If neither is specified, defaults to 'main'.
   branch: main
+  # Alternatively, use a git tag instead of a branch.
+  # Useful for release-based deployments (e.g., v1.2.3).
+  # Mutually exclusive with 'branch'.
+  # tag: v1.0.0
   # The path to the docker compose file where stack
   # is defined
   compose_file: /path/to/compose.yaml

--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v27.1.1+incompatible // indirect
+	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -171,7 +171,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/swarmcd/concurrency_test.go
+++ b/swarmcd/concurrency_test.go
@@ -24,10 +24,12 @@ func TestConcurrentStatusRead(t *testing.T) {
 		name := fmt.Sprintf("test-stack-%d", i)
 		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 		repos[i] = repo
-		s := newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false)
+		s := newSwarmStack(name, repo, "main", "", "docker-compose.yaml", nil, "", false)
 		stacks = append(stacks, s)
 		stackStatus[name] = &StackStatus{
 			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 			Revision: "abc12345",
 		}
 	}
@@ -103,6 +105,8 @@ func TestGetStackStatusReturnsSnapshot(t *testing.T) {
 			Error:    "",
 			Revision: "aabb1122",
 			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 		},
 	}
 	stacks = nil
@@ -149,9 +153,11 @@ func TestLockOrderingNoDeadlock(t *testing.T) {
 		name := fmt.Sprintf("deadlock-test-%d", i)
 		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 		repos[i] = repo
-		stacks = append(stacks, newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false))
+		stacks = append(stacks, newSwarmStack(name, repo, "main", "", "docker-compose.yaml", nil, "", false))
 		stackStatus[name] = &StackStatus{
-			RepoURL: "http://example.com",
+			RepoURL:  "http://example.com",
+			RefType:  "branch",
+			RefValue: "main",
 		}
 	}
 	stateMu.Unlock()

--- a/swarmcd/concurrency_test.go
+++ b/swarmcd/concurrency_test.go
@@ -1,0 +1,200 @@
+package swarmcd
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestConcurrentStatusRead spawns N goroutines reading GetStackStatus() while
+// reconciliation-style goroutines write to stackStatus. This test is designed
+// to be run with -race to detect data races.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestConcurrentStatusRead(t *testing.T) {
+	// Set up test state: populate stackStatus and stacks with test data
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{}
+	stacks = nil
+
+	const numStacks = 5
+	repos := make([]*stackRepo, numStacks)
+	for i := 0; i < numStacks; i++ {
+		name := fmt.Sprintf("test-stack-%d", i)
+		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+		repos[i] = repo
+		s := newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false)
+		stacks = append(stacks, s)
+		stackStatus[name] = &StackStatus{
+			RepoURL:  "http://example.com",
+			Revision: "abc12345",
+		}
+	}
+	stateMu.Unlock()
+
+	// Restore original state when done
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	var wg sync.WaitGroup
+	const numReaders = 10
+	const numWriters = 5
+	const iterations = 100
+
+	// Start reader goroutines that call GetStackStatus() concurrently
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				status := GetStackStatus()
+				// Access the returned snapshot to ensure it's a real copy
+				for k, v := range status {
+					_ = k
+					_ = v.Error
+					_ = v.Revision
+					_ = v.RepoURL
+				}
+			}
+		}()
+	}
+
+	// Start writer goroutines that simulate reconciliation writes
+	// These follow the correct lock ordering: repo.lock first, then stateMu
+	for i := 0; i < numWriters; i++ {
+		stackIdx := i % numStacks
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("test-stack-%d", idx)
+			repo := repos[idx]
+			for j := 0; j < iterations; j++ {
+				// Simulate lock ordering: acquire repo.lock, do work, release, then acquire stateMu
+				repo.lock.Lock()
+				// Simulate some work under repo lock
+				revision := fmt.Sprintf("%08x", j)
+				repo.lock.Unlock()
+
+				stateMu.Lock()
+				stackStatus[name].Revision = revision
+				stackStatus[name].Error = ""
+				stateMu.Unlock()
+			}
+		}(stackIdx)
+	}
+
+	wg.Wait()
+}
+
+// TestGetStackStatusReturnsSnapshot verifies that GetStackStatus returns a
+// copy so mutations to the returned map don't affect the original.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestGetStackStatusReturnsSnapshot(t *testing.T) {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{
+		"snap-test": {
+			Error:    "",
+			Revision: "aabb1122",
+			RepoURL:  "http://example.com",
+		},
+	}
+	stacks = nil
+	stateMu.Unlock()
+
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	snapshot := GetStackStatus()
+
+	// Mutate the snapshot
+	snapshot["snap-test"].Revision = "MUTATED"
+	snapshot["extra"] = &StackStatus{Revision: "bogus"}
+
+	// Verify original is unchanged
+	stateMu.RLock()
+	if stackStatus["snap-test"].Revision != "aabb1122" {
+		t.Errorf("original stackStatus was mutated: got revision %q, want %q", stackStatus["snap-test"].Revision, "aabb1122")
+	}
+	if _, exists := stackStatus["extra"]; exists {
+		t.Error("original stackStatus should not contain 'extra' key")
+	}
+	stateMu.RUnlock()
+}
+
+// TestLockOrderingNoDeadlock verifies that the lock ordering (release repo.lock
+// before acquiring stateMu) does not cause deadlock when multiple goroutines
+// follow the pattern simultaneously.
+// This test must not use t.Parallel() — it mutates package-level globals.
+func TestLockOrderingNoDeadlock(t *testing.T) {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = map[string]*StackStatus{}
+	stacks = nil
+
+	const numStacks = 3
+	repos := make([]*stackRepo, numStacks)
+	for i := 0; i < numStacks; i++ {
+		name := fmt.Sprintf("deadlock-test-%d", i)
+		repo := &stackRepo{name: name, path: "/tmp/test", url: "http://example.com", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+		repos[i] = repo
+		stacks = append(stacks, newSwarmStack(name, repo, "main", "docker-compose.yaml", nil, "", false))
+		stackStatus[name] = &StackStatus{
+			RepoURL: "http://example.com",
+		}
+	}
+	stateMu.Unlock()
+
+	defer func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}()
+
+	var wg sync.WaitGroup
+
+	// Simulate multiple reconciliation goroutines with correct lock ordering
+	for i := 0; i < numStacks; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("deadlock-test-%d", idx)
+			repo := repos[idx]
+			for j := 0; j < 50; j++ {
+				// Correct ordering: repo.lock then release, then stateMu
+				repo.lock.Lock()
+				revision := fmt.Sprintf("%08x", j)
+				repo.lock.Unlock()
+
+				stateMu.Lock()
+				stackStatus[name].Revision = revision
+				stateMu.Unlock()
+			}
+		}(i)
+	}
+
+	// Concurrent readers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = GetStackStatus()
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -17,6 +17,7 @@ type StackStatus struct {
 	Error    string
 	Revision string
 	RepoURL  string
+	Ref      string
 }
 
 var config *util.Config = &util.Configs
@@ -97,11 +98,30 @@ func initStacks() error {
 		if !ok {
 			return fmt.Errorf("error initializing %s stack, no such repo: %s", stack, stackConfig.Repo)
 		}
+
+		// Validate branch/tag mutual exclusivity and determine ref
+		branch := stackConfig.Branch
+		tag := stackConfig.Tag
+		var ref string
+
+		if branch != "" && tag != "" {
+			return fmt.Errorf("error initializing %s stack: cannot specify both branch and tag", stack)
+		} else if tag != "" {
+			ref = "tag:" + tag
+		} else if branch != "" {
+			ref = "branch:" + branch
+		} else {
+			// Default to main branch for backward compatibility
+			branch = "main"
+			ref = "branch:main"
+		}
+
 		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
-		swarmStack := newSwarmStack(stack, stackRepo, stackConfig.Branch, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+		swarmStack := newSwarmStack(stack, stackRepo, branch, tag, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
 		stacks = append(stacks, swarmStack)
 		stackStatus[stack] = &StackStatus{}
 		stackStatus[stack].RepoURL = stackRepo.url
+		stackStatus[stack].Ref = ref
 	}
 	return nil
 }

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/flags"
@@ -14,11 +15,27 @@ import (
 )
 
 type StackStatus struct {
-	Error    string
-	Revision string
-	RepoURL  string
-	Ref      string
+	Error          string
+	Revision       string
+	RepoURL        string
+	RefType        string
+	RefValue       string
+	ComposeFile    string
+	LastChangeAt   *time.Time
+	LastDeployedAt *time.Time
 }
+
+// RuntimeInfo holds instance-level metadata set at startup.
+type RuntimeInfo struct {
+	BootedAt time.Time
+	Version  string
+}
+
+// Version is the application version, overridden at build time via
+// -ldflags "-X github.com/m-adawi/swarm-cd/swarmcd.Version=..."
+var Version = "dev"
+
+var runtimeInfo RuntimeInfo
 
 var config *util.Config = &util.Configs
 
@@ -29,6 +46,11 @@ var repos map[string]*stackRepo = map[string]*stackRepo{}
 var dockerCli *command.DockerCli
 
 func Init() (err error) {
+	runtimeInfo = RuntimeInfo{
+		BootedAt: time.Now(),
+		Version:  Version,
+	}
+
 	err = initRepos()
 	if err != nil {
 		return err
@@ -102,26 +124,35 @@ func initStacks() error {
 		// Validate branch/tag mutual exclusivity and determine ref
 		branch := stackConfig.Branch
 		tag := stackConfig.Tag
-		var ref string
+		var refType, refValue string
 
 		if branch != "" && tag != "" {
 			return fmt.Errorf("error initializing %s stack: cannot specify both branch and tag", stack)
 		} else if tag != "" {
-			ref = "tag:" + tag
+			refType = "tag"
+			refValue = tag
 		} else if branch != "" {
-			ref = "branch:" + branch
+			refType = "branch"
+			refValue = branch
 		} else {
 			// Default to main branch for backward compatibility
 			branch = "main"
-			ref = "branch:main"
+			refType = "branch"
+			refValue = "main"
 		}
 
 		discoverSecrets := config.SopsSecretsDiscovery || stackConfig.SopsSecretsDiscovery
 		swarmStack := newSwarmStack(stack, stackRepo, branch, tag, stackConfig.ComposeFile, stackConfig.SopsFiles, stackConfig.ValuesFile, discoverSecrets)
+
+		stateMu.Lock()
 		stacks = append(stacks, swarmStack)
-		stackStatus[stack] = &StackStatus{}
-		stackStatus[stack].RepoURL = stackRepo.url
-		stackStatus[stack].Ref = ref
+		stackStatus[stack] = &StackStatus{
+			RepoURL:     stackRepo.url,
+			RefType:     refType,
+			RefValue:    refValue,
+			ComposeFile: stackConfig.ComposeFile,
+		}
+		stateMu.Unlock()
 	}
 	return nil
 }

--- a/swarmcd/patch.go
+++ b/swarmcd/patch.go
@@ -1,0 +1,217 @@
+package swarmcd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+// PatchRequest represents a partial update to a stack's configuration.
+// Pointer fields distinguish "not provided" (nil) from "set to empty" ("").
+type PatchRequest struct {
+	Branch      *string `json:"branch"`
+	Tag         *string `json:"tag"`
+	ComposeFile *string `json:"compose_file"`
+	RepoURL     *string `json:"repo_url"`
+}
+
+// PatchResponse contains the result of a successful patch operation.
+type PatchResponse struct {
+	Message  string   `json:"message"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// ValidationError is returned when a patch request is invalid.
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+// NotFoundError is returned when a requested stack does not exist.
+type NotFoundError struct {
+	Message string
+}
+
+func (e *NotFoundError) Error() string { return e.Message }
+
+// PatchStack applies a partial update to the named stack's configuration.
+// It uses a three-phase approach to respect lock ordering:
+//   - Phase 1 (stateMu.RLock): validate the request and gather references
+//   - Phase 2 (no locks): perform I/O (git clone for repo URL changes)
+//   - Phase 3 (stateMu.Lock): apply state changes and persist
+//
+// This ensures stateMu is never held while repo.lock is acquired, which
+// would violate the lock ordering rule (see swarmcd.go).
+func PatchStack(name string, req PatchRequest) (*PatchResponse, error) {
+	// --- Phase 1: Validate under RLock ---
+	stateMu.RLock()
+
+	if _, ok := stackStatus[name]; !ok {
+		stateMu.RUnlock()
+		return nil, &NotFoundError{Message: fmt.Sprintf("stack '%s' not found", name)}
+	}
+
+	stackCfg, ok := config.StackConfigs[name]
+	if !ok {
+		stateMu.RUnlock()
+		return nil, &NotFoundError{Message: fmt.Sprintf("stack config '%s' not found", name)}
+	}
+
+	if req.Branch == nil && req.Tag == nil && req.ComposeFile == nil && req.RepoURL == nil {
+		stateMu.RUnlock()
+		return nil, &ValidationError{Message: "patch request must include at least one field"}
+	}
+
+	if req.Branch != nil && req.Tag != nil {
+		stateMu.RUnlock()
+		return nil, &ValidationError{Message: "cannot set both branch and tag in the same request"}
+	}
+
+	var warnings []string
+	var repo *stackRepo
+	var repoName string
+
+	if req.RepoURL != nil {
+		repoName = stackCfg.Repo
+		repo = repos[repoName]
+
+		shared := findSharedRepoStacks(repoName, name)
+		if len(shared) > 0 {
+			warnings = append(warnings, fmt.Sprintf("repo '%s' is also used by: %v — they will be affected", repoName, shared))
+		}
+	}
+
+	stateMu.RUnlock()
+
+	// --- Phase 2: I/O without any locks held ---
+	if req.RepoURL != nil {
+		if err := cloneToTempThenSwap(repo, *req.RepoURL); err != nil {
+			return nil, &ValidationError{Message: fmt.Sprintf("failed to update repo URL: %v", err)}
+		}
+	}
+
+	// --- Phase 3: Apply state changes under Lock ---
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	// Re-validate after re-acquiring lock (state may have changed)
+	status, ok := stackStatus[name]
+	if !ok {
+		return nil, &NotFoundError{Message: fmt.Sprintf("stack '%s' not found", name)}
+	}
+
+	var stack *swarmStack
+	for _, s := range stacks {
+		if s.name == name {
+			stack = s
+			break
+		}
+	}
+	if stack == nil {
+		return nil, &NotFoundError{Message: fmt.Sprintf("stack object '%s' not found", name)}
+	}
+
+	// Re-read stackCfg under write lock
+	stackCfg = config.StackConfigs[name]
+
+	if req.RepoURL != nil {
+		repoCfg := config.RepoConfigs[repoName]
+		repoCfg.Url = *req.RepoURL
+		status.RepoURL = *req.RepoURL
+	}
+
+	if req.Branch != nil || req.Tag != nil {
+		updateSwarmStackRef(stack, stackCfg, status, req.Branch, req.Tag)
+	}
+
+	if req.ComposeFile != nil {
+		updateSwarmStackComposeFile(stack, stackCfg, status, *req.ComposeFile)
+	}
+
+	if err := util.PersistConfigs(); err != nil {
+		return nil, fmt.Errorf("failed to persist configs: %w", err)
+	}
+
+	return &PatchResponse{
+		Message:  fmt.Sprintf("stack '%s' updated successfully", name),
+		Warnings: warnings,
+	}, nil
+}
+
+// findSharedRepoStacks returns the names of other stacks that use the same repo.
+func findSharedRepoStacks(repoName, excludeStack string) []string {
+	var shared []string
+	for name, cfg := range config.StackConfigs {
+		if name != excludeStack && cfg.Repo == repoName {
+			shared = append(shared, name)
+		}
+	}
+	return shared
+}
+
+// cloneToTempThenSwap clones the new URL to a temp directory in the same
+// parent as the repo, then swaps the repo's path and git object.
+// Must be called WITHOUT holding stateMu (acquires repo.lock internally).
+func cloneToTempThenSwap(repo *stackRepo, newURL string) error {
+	repo.lock.Lock()
+	defer repo.lock.Unlock()
+
+	// Create temp dir in the same parent to ensure same filesystem for rename
+	tmpDir, err := os.MkdirTemp(filepath.Dir(repo.path), "swarmcd-repo-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+
+	gitRepo, err := git.PlainClone(tmpDir, false, &git.CloneOptions{
+		URL:  newURL,
+		Auth: repo.auth,
+	})
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to clone %s: %w", newURL, err)
+	}
+
+	oldPath := repo.path
+	if err := os.RemoveAll(oldPath); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to remove old repo dir: %w", err)
+	}
+	if err := os.Rename(tmpDir, oldPath); err != nil {
+		os.RemoveAll(tmpDir)
+		return fmt.Errorf("failed to move new repo into place: %w", err)
+	}
+
+	repo.gitRepoObject = gitRepo
+	repo.url = newURL
+	return nil
+}
+
+// updateSwarmStackRef updates the branch/tag ref on the stack.
+func updateSwarmStackRef(stack *swarmStack, cfg *util.StackConfig, status *StackStatus, branch, tag *string) {
+	if branch != nil {
+		stack.branch = *branch
+		stack.tag = ""
+		cfg.Branch = *branch
+		cfg.Tag = ""
+		status.RefType = "branch"
+		status.RefValue = *branch
+	} else if tag != nil {
+		stack.tag = *tag
+		stack.branch = ""
+		cfg.Tag = *tag
+		cfg.Branch = ""
+		status.RefType = "tag"
+		status.RefValue = *tag
+	}
+}
+
+// updateSwarmStackComposeFile updates the compose file path on the stack.
+func updateSwarmStackComposeFile(stack *swarmStack, cfg *util.StackConfig, status *StackStatus, composeFile string) {
+	stack.composePath = composeFile
+	cfg.ComposeFile = composeFile
+	status.ComposeFile = composeFile
+}

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
@@ -94,6 +95,50 @@ func (repo *stackRepo) pullChanges(branch string) (revision string, err error) {
 	ref, err := repo.gitRepoObject.Head()
 	if err != nil {
 		return "", fmt.Errorf("could not get HEAD commit hash of %s branch in %s repo: %w", branch, repo.name, err)
+	}
+	// return HEAD commit short hash
+	return ref.Hash().String()[:8], nil
+}
+
+func (repo *stackRepo) fetchTag(tag string) (revision string, err error) {
+	log := logger.With(slog.String("repo", repo.name), slog.String("tag", tag))
+
+	log.Debug("getting repo worktree...")
+	workTree, err := repo.gitRepoObject.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("could not get %s repo worktree: %w", repo.name, err)
+	}
+
+	// Fetch the specific tag from remote
+	log.Debug("fetching tag...")
+	fetchOptions := &git.FetchOptions{
+		RemoteName: "origin",
+		Auth:       repo.auth,
+		RefSpecs:   []gitconfig.RefSpec{gitconfig.RefSpec("+refs/tags/" + tag + ":refs/tags/" + tag)},
+		Force:      true,
+	}
+	err = repo.gitRepoObject.Fetch(fetchOptions)
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		if err.Error() == "authentication required" {
+			err = fmt.Errorf("authentication failed")
+		}
+		return "", fmt.Errorf("could not fetch tag %s in %s repo: %w", tag, repo.name, err)
+	}
+
+	log.Debug("checking out tag...")
+	tagRef := plumbing.ReferenceName("refs/tags/" + tag)
+	err = workTree.Checkout(&git.CheckoutOptions{
+		Branch: tagRef,
+		Force:  true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not checkout tag %s in %s: %w", tag, repo.name, err)
+	}
+
+	log.Debug("getting revision...")
+	ref, err := repo.gitRepoObject.Head()
+	if err != nil {
+		return "", fmt.Errorf("could not get HEAD commit hash of tag %s in %s repo: %w", tag, repo.name, err)
 	}
 	// return HEAD commit short hash
 	return ref.Hash().String()[:8], nil

--- a/swarmcd/restart.go
+++ b/swarmcd/restart.go
@@ -1,0 +1,69 @@
+package swarmcd
+
+import (
+	"context"
+	"sync"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+)
+
+// ServiceAPI is the subset of the Docker API used for service operations.
+// It is satisfied by the client returned from dockerCli.Client().
+type ServiceAPI interface {
+	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
+}
+
+var (
+	serviceAPI     ServiceAPI
+	serviceAPIMu   sync.Mutex
+	serviceAPIInit bool
+)
+
+// GetDockerServiceAPI returns a lazily-initialized Docker service client.
+func GetDockerServiceAPI() ServiceAPI {
+	serviceAPIMu.Lock()
+	defer serviceAPIMu.Unlock()
+	if !serviceAPIInit {
+		serviceAPI = dockerCli.Client()
+		serviceAPIInit = true
+	}
+	return serviceAPI
+}
+
+// SetServiceAPIForTest replaces the Docker service client for testing
+// and returns a cleanup function that restores the original.
+func SetServiceAPIForTest(api ServiceAPI) func() {
+	serviceAPIMu.Lock()
+	old := serviceAPI
+	oldInit := serviceAPIInit
+	serviceAPI = api
+	serviceAPIInit = true
+	serviceAPIMu.Unlock()
+	return func() {
+		serviceAPIMu.Lock()
+		serviceAPI = old
+		serviceAPIInit = oldInit
+		serviceAPIMu.Unlock()
+	}
+}
+
+// StackExists reports whether the named stack is known to SwarmCD.
+func StackExists(name string) bool {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	_, ok := stackStatus[name]
+	return ok
+}
+
+// GetStackNames returns the names of all managed stacks.
+func GetStackNames() []string {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	names := make([]string, 0, len(stackStatus))
+	for k := range stackStatus {
+		names = append(names, k)
+	}
+	return names
+}

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -8,7 +8,7 @@ import (
 // External objects are ignored by the rotation
 func TestRotateExternalObjects(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 	}
@@ -21,7 +21,7 @@ func TestRotateExternalObjects(t *testing.T) {
 // Secrets are discovered, external secrets are ignored
 func TestSecretDiscovery(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false)
+	stack := newSwarmStack("test", repo, "main", "", "stacks/docker-compose.yaml", nil, "", false)
 	stackString := []byte(`services:
   my-service:
     image: my-image
@@ -46,5 +46,54 @@ secrets:
 	}
 	if sopsFiles[0] != "stacks/secrets/secret.yaml" {
 		t.Errorf("unexpected sops file: %s", sopsFiles[0])
+	}
+}
+
+// refAttr returns branch attribute when branch is set
+func TestRefAttrBranch(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "main", "", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "branch" {
+		t.Errorf("expected key 'branch', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "main" {
+		t.Errorf("expected value 'main', got '%s'", attr.Value.String())
+	}
+}
+
+// refAttr returns tag attribute when tag is set
+func TestRefAttrTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "", "v1.2.3", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag', got '%s'", attr.Key)
+	}
+	if attr.Value.String() != "v1.2.3" {
+		t.Errorf("expected value 'v1.2.3', got '%s'", attr.Value.String())
+	}
+}
+
+// newSwarmStack correctly stores tag
+func TestNewSwarmStackWithTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("mystack", repo, "", "v2.0.0", "compose.yaml", nil, "", false)
+	if stack.tag != "v2.0.0" {
+		t.Errorf("expected tag 'v2.0.0', got '%s'", stack.tag)
+	}
+	if stack.branch != "" {
+		t.Errorf("expected empty branch, got '%s'", stack.branch)
+	}
+}
+
+// Verify refAttr prefers tag over branch when both could theoretically be set
+func TestRefAttrPrefersTag(t *testing.T) {
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	// Even if branch has a value, tag takes precedence
+	stack := newSwarmStack("test", repo, "main", "v1.0.0", "docker-compose.yaml", nil, "", false)
+	attr := stack.refAttr()
+	if attr.Key != "tag" {
+		t.Errorf("expected key 'tag' to take precedence, got '%s'", attr.Key)
 	}
 }

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -9,12 +9,21 @@ import (
 var stackStatus map[string]*StackStatus = map[string]*StackStatus{}
 var stacks []*swarmStack
 
+// stateMu protects stackStatus and stacks from concurrent access.
+// Lock ordering: stateMu must never be acquired while repo.lock is held.
+// Acquiring stateMu independently (without any repo.lock) is always safe.
+var stateMu sync.RWMutex
+
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {
 		var waitGroup sync.WaitGroup
 		logger.Info("updating stacks...")
-		for _, swarmStack := range stacks {
+		stateMu.RLock()
+		currentStacks := make([]*swarmStack, len(stacks))
+		copy(currentStacks, stacks)
+		stateMu.RUnlock()
+		for _, swarmStack := range currentStacks {
 			waitGroup.Add(1)
 			go updateStackThread(swarmStack, &waitGroup)
 		}
@@ -25,24 +34,42 @@ func Run() {
 }
 
 func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
-	repoLock := swarmStack.repo.lock
-	repoLock.Lock()
-	defer repoLock.Unlock()
 	defer waitGroup.Done()
 
+	repoLock := swarmStack.repo.lock
+	repoLock.Lock()
 	logger.Info(fmt.Sprintf("updating %s stack", swarmStack.name))
 	revision, err := swarmStack.updateStack()
+	repoLock.Unlock() // Release repo.lock BEFORE acquiring stateMu
+
+	stateMu.Lock()
+	status := stackStatus[swarmStack.name]
 	if err != nil {
-		stackStatus[swarmStack.name].Error = err.Error()
+		status.Error = err.Error()
+	} else {
+		status.Error = ""
+		status.Revision = revision
+	}
+	stateMu.Unlock()
+
+	if err != nil {
 		logger.Error(err.Error())
 		return
 	}
-
-	stackStatus[swarmStack.name].Error = ""
-	stackStatus[swarmStack.name].Revision = revision
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }
 
+// GetStackStatus returns a snapshot of all stack statuses under a read lock.
+// The returned map is a copy — callers cannot mutate the original values.
+// StackStatus currently contains only value types (strings); update this
+// copy logic if pointer or slice fields are added.
 func GetStackStatus() map[string]*StackStatus {
-	return stackStatus
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	snapshot := make(map[string]*StackStatus, len(stackStatus))
+	for k, v := range stackStatus {
+		cp := *v
+		snapshot[k] = &cp
+	}
+	return snapshot
 }

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -49,13 +49,13 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	if err != nil {
 		status.Error = err.Error()
 	} else {
-		// Set LastChangeAt when the revision changes
+		// Update timestamps only when the revision actually changes
 		if revision != status.Revision {
 			status.LastChangeAt = &now
+			status.LastDeployedAt = &now
 		}
 		status.Error = ""
 		status.Revision = revision
-		status.LastDeployedAt = &now
 	}
 	stateMu.Unlock()
 

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -42,13 +42,20 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	revision, err := swarmStack.updateStack()
 	repoLock.Unlock() // Release repo.lock BEFORE acquiring stateMu
 
+	now := time.Now()
+
 	stateMu.Lock()
 	status := stackStatus[swarmStack.name]
 	if err != nil {
 		status.Error = err.Error()
 	} else {
+		// Set LastChangeAt when the revision changes
+		if revision != status.Revision {
+			status.LastChangeAt = &now
+		}
 		status.Error = ""
 		status.Revision = revision
+		status.LastDeployedAt = &now
 	}
 	stateMu.Unlock()
 
@@ -59,16 +66,32 @@ func updateStackThread(swarmStack *swarmStack, waitGroup *sync.WaitGroup) {
 	logger.Info(fmt.Sprintf("done updating %s stack", swarmStack.name))
 }
 
+// GetRuntimeInfo returns a copy of the instance's runtime metadata.
+// Protected by stateMu for consistency, though in practice runtimeInfo
+// is only written once during Init() before Run() starts.
+func GetRuntimeInfo() RuntimeInfo {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+	return runtimeInfo
+}
+
 // GetStackStatus returns a snapshot of all stack statuses under a read lock.
-// The returned map is a copy — callers cannot mutate the original values.
-// StackStatus currently contains only value types (strings); update this
-// copy logic if pointer or slice fields are added.
+// Pointer fields (LastChangeAt, LastDeployedAt) are deep-copied so callers
+// cannot mutate the original values.
 func GetStackStatus() map[string]*StackStatus {
 	stateMu.RLock()
 	defer stateMu.RUnlock()
 	snapshot := make(map[string]*StackStatus, len(stackStatus))
 	for k, v := range stackStatus {
 		cp := *v
+		if v.LastChangeAt != nil {
+			t := *v.LastChangeAt
+			cp.LastChangeAt = &t
+		}
+		if v.LastDeployedAt != nil {
+			t := *v.LastDeployedAt
+			cp.LastDeployedAt = &t
+		}
 		snapshot[k] = &cp
 	}
 	return snapshot

--- a/swarmcd/test_helpers.go
+++ b/swarmcd/test_helpers.go
@@ -1,0 +1,138 @@
+// test_helpers.go lives in the swarmcd package (not a _test.go file) so that
+// test files in other packages (e.g., web/) can call these helpers to safely
+// swap internal state. This is intentional — SwarmCD is a standalone binary,
+// not a library, so the exported surface area is not a concern.
+package swarmcd
+
+import (
+	"sync"
+
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+// SetStackStatusForTest replaces the internal stackStatus map with the given
+// test data and returns a cleanup function that restores the original state.
+// This is intended for use in tests only.
+func SetStackStatusForTest(testStatus map[string]*StackStatus) func() {
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	stackStatus = testStatus
+	stacks = nil
+	stateMu.Unlock()
+
+	return func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		stateMu.Unlock()
+	}
+}
+
+// SetRuntimeInfoForTest replaces the internal runtimeInfo with the given
+// test data and returns a cleanup function that restores the original state.
+// This is intended for use in tests only.
+func SetRuntimeInfoForTest(info RuntimeInfo) func() {
+	stateMu.Lock()
+	old := runtimeInfo
+	runtimeInfo = info
+	stateMu.Unlock()
+	return func() {
+		stateMu.Lock()
+		runtimeInfo = old
+		stateMu.Unlock()
+	}
+}
+
+// TestStackDef describes a stack for test setup purposes.
+type TestStackDef struct {
+	Name        string
+	RepoName    string
+	RepoPath    string
+	RepoURL     string
+	Branch      string
+	Tag         string
+	ComposeFile string
+}
+
+// SetFullStateForTest builds and replaces all internal state (stackStatus,
+// stacks, repos, and util.Configs) from the given definitions. Returns a
+// cleanup function that restores the original state.
+func SetFullStateForTest(defs []TestStackDef) func() {
+	oldRepoConfigs := config.RepoConfigs
+	oldStackConfigs := config.StackConfigs
+
+	newStatus := make(map[string]*StackStatus)
+	newRepos := make(map[string]*stackRepo)
+	newRepoCfgs := make(map[string]*util.RepoConfig)
+	newStackCfgs := make(map[string]*util.StackConfig)
+	var newStacks []*swarmStack
+
+	for _, d := range defs {
+		// Create repo if not already created
+		if _, ok := newRepos[d.RepoName]; !ok {
+			newRepos[d.RepoName] = &stackRepo{
+				name:          d.RepoName,
+				path:          d.RepoPath,
+				url:           d.RepoURL,
+				auth:          nil,
+				lock:          &sync.Mutex{},
+				gitRepoObject: nil,
+			}
+			newRepoCfgs[d.RepoName] = &util.RepoConfig{Url: d.RepoURL}
+		}
+
+		repo := newRepos[d.RepoName]
+
+		var refType, refValue string
+		if d.Tag != "" {
+			refType = "tag"
+			refValue = d.Tag
+		} else if d.Branch != "" {
+			refType = "branch"
+			refValue = d.Branch
+		} else {
+			refType = "branch"
+			refValue = "main"
+		}
+
+		newStatus[d.Name] = &StackStatus{
+			RepoURL:     d.RepoURL,
+			RefType:     refType,
+			RefValue:    refValue,
+			ComposeFile: d.ComposeFile,
+		}
+
+		newStackCfgs[d.Name] = &util.StackConfig{
+			Repo:        d.RepoName,
+			Branch:      d.Branch,
+			Tag:         d.Tag,
+			ComposeFile: d.ComposeFile,
+		}
+
+		s := newSwarmStack(d.Name, repo, d.Branch, d.Tag, d.ComposeFile, nil, "", false)
+		newStacks = append(newStacks, s)
+	}
+
+	stateMu.Lock()
+	oldStatus := stackStatus
+	oldStacks := stacks
+	oldRepos := repos
+	stackStatus = newStatus
+	stacks = newStacks
+	repos = newRepos
+	stateMu.Unlock()
+
+	config.RepoConfigs = newRepoCfgs
+	config.StackConfigs = newStackCfgs
+
+	return func() {
+		stateMu.Lock()
+		stackStatus = oldStatus
+		stacks = oldStacks
+		repos = oldRepos
+		stateMu.Unlock()
+		config.RepoConfigs = oldRepoConfigs
+		config.StackConfigs = oldStackConfigs
+	}
+}

--- a/ui/src/components/StatusCard.tsx
+++ b/ui/src/components/StatusCard.tsx
@@ -5,12 +5,14 @@ function StatusCard({
   name,
   error,
   revision,
-  repoURL
+  repoURL,
+  gitRef
 }: Readonly<{
   name: string
   error: string
   revision: string
   repoURL: string
+  gitRef: string
 }>): React.ReactElement {
   return (
     <Box borderWidth="1px" borderRadius="sm" overflow="hidden" p={4} boxShadow="lg">
@@ -24,6 +26,9 @@ function StatusCard({
             <Text color="red.500">{error}</Text>
           </>
         )}
+
+        <KeyText>Watching:</KeyText>
+        <Text>{gitRef}</Text>
 
         <KeyText>Revision:</KeyText>
         <Text>{revision}</Text>

--- a/ui/src/components/StatusCardList.tsx
+++ b/ui/src/components/StatusCardList.tsx
@@ -21,7 +21,7 @@ function StatusCardList({ statuses, query }: Readonly<{ statuses: StackStatus[];
         </Text>
       ) : (
         filteredStatuses.map((item, index) => (
-          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} />
+          <StatusCard key={index} name={item.Name} error={item.Error} revision={item.Revision} repoURL={item.RepoURL} gitRef={item.Ref} />
         ))
       )}
     </>

--- a/ui/src/hooks/dummyStackStatuses.json
+++ b/ui/src/hooks/dummyStackStatuses.json
@@ -3,18 +3,21 @@
     "Name": "Project Alpha",
     "Error": "",
     "Revision": "v1.0.1",
-    "RepoURL": "https://github.com/user/project-alpha"
+    "RepoURL": "https://github.com/user/project-alpha",
+    "Ref": "branch:main"
   },
   {
     "Name": "Project Beta",
     "Error": "Failed to build",
     "Revision": "v2.3.4",
-    "RepoURL": "https://github.com/user/project-beta"
+    "RepoURL": "https://github.com/user/project-beta",
+    "Ref": "tag:v2.3.4"
   },
   {
     "Name": "Project Gamma",
     "Error": "",
     "Revision": "v0.9.8",
-    "RepoURL": "https://github.com/user/project-gamma"
+    "RepoURL": "https://github.com/user/project-gamma",
+    "Ref": "branch:develop"
   }
 ]

--- a/ui/src/hooks/useFetchStatuses.tsx
+++ b/ui/src/hooks/useFetchStatuses.tsx
@@ -6,6 +6,7 @@ export interface StackStatus {
   Error: string
   Revision: string
   RepoURL: string
+  Ref: string
 }
 
 async function fetchFromServer(): Promise<StackStatus[]> {

--- a/ui/tests/components/StatusCard.test.tsx
+++ b/ui/tests/components/StatusCard.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from "@testing-library/react"
 import StatusCard from "../../src/components/StatusCard"
 
 describe("StatusCard", () => {
-  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234" }
+  const status = { name: "Some Name Here", revision: "3.76.1", repoURL: "https://www.github.com/1234", gitRef: "branch:main" }
 
   it("should render name, revision, and repoURL properties", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     for (const value of Object.values(status)) {
       const valueElement = screen.getByText(new RegExp(value, "i"))
@@ -14,7 +14,7 @@ describe("StatusCard", () => {
   })
 
   it("should render repoURL as a link", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const repoUrlElement = screen.getByRole("link", { name: status.repoURL })
     expect(repoUrlElement).toBeInTheDocument()
@@ -22,14 +22,14 @@ describe("StatusCard", () => {
   })
 
   it("should not render error if it is empty", () => {
-    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={""} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).not.toBeInTheDocument()
   })
 
   it("should render error if it is not empty", () => {
-    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} />)
+    render(<StatusCard name={status.name} error={"Oh no!"} revision={status.revision} repoURL={status.repoURL} gitRef={status.gitRef} />)
 
     const errorText = screen.queryByText(/error/i)
     expect(errorText).toBeInTheDocument()

--- a/ui/tests/components/StatusCardList.test.tsx
+++ b/ui/tests/components/StatusCardList.test.tsx
@@ -4,9 +4,9 @@ import { StackStatus } from "../../src/hooks/useFetchStatuses"
 
 describe("StatusCardList", () => {
   const statuses: StackStatus[] = [
-    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com" },
-    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com" },
-    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com" }
+    { Name: "Foobar", Error: "", Revision: "1.0.0", RepoURL: "https://www.url1.com", Ref: "branch:main" },
+    { Name: "FooFoo", Error: "", Revision: "2.0.0", RepoURL: "https://www.url2.com", Ref: "tag:v2.0.0" },
+    { Name: "Boobaz", Error: "Oh no!!!", Revision: "2.0.0", RepoURL: "https://www.url3.com", Ref: "branch:develop" }
   ]
 
   it("should render no statuses if the list of statuses is empty", () => {

--- a/util/config.go
+++ b/util/config.go
@@ -10,6 +10,7 @@ import (
 type StackConfig struct {
 	Repo                 string
 	Branch               string
+	Tag                  string
 	ComposeFile          string   `mapstructure:"compose_file"`
 	ValuesFile           string   `mapstructure:"values_file"`
 	SopsFiles            []string `mapstructure:"sops_files"`

--- a/util/config.go
+++ b/util/config.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/goccy/go-yaml"
 	"github.com/spf13/viper"
 )
 
@@ -24,20 +25,20 @@ type ConfigConflict struct {
 var Conflict ConfigConflict
 
 type StackConfig struct {
-	Repo                 string
-	Branch               string
-	Tag                  string
-	ComposeFile          string   `mapstructure:"compose_file"`
-	ValuesFile           string   `mapstructure:"values_file"`
-	SopsFiles            []string `mapstructure:"sops_files"`
-	SopsSecretsDiscovery bool     `mapstructure:"sops_secrets_discovery"`
+	Repo                 string   `yaml:"repo"`
+	Branch               string   `yaml:"branch,omitempty"`
+	Tag                  string   `yaml:"tag,omitempty"`
+	ComposeFile          string   `mapstructure:"compose_file" yaml:"compose_file,omitempty"`
+	ValuesFile           string   `mapstructure:"values_file" yaml:"values_file,omitempty"`
+	SopsFiles            []string `mapstructure:"sops_files" yaml:"sops_files,omitempty"`
+	SopsSecretsDiscovery bool     `mapstructure:"sops_secrets_discovery" yaml:"sops_secrets_discovery,omitempty"`
 }
 
 type RepoConfig struct {
-	Url          string
-	Username     string
-	Password     string
-	PasswordFile string `mapstructure:"password_file"`
+	Url          string `yaml:"url"`
+	Username     string `yaml:"username,omitempty"`
+	Password     string `yaml:"password,omitempty"`
+	PasswordFile string `mapstructure:"password_file" yaml:"password_file,omitempty"`
 }
 
 type Config struct {
@@ -132,6 +133,38 @@ func logConfigWarnings(log *slog.Logger) {
 	for _, w := range ConfigWarnings() {
 		log.Warn(w)
 	}
+}
+
+// PersistConfigs writes the current stack and repo configurations to their
+// respective split files (stacks.yaml, repos.yaml) using atomic writes.
+// If config is defined inline in config.yaml, these files may be ignored on
+// next startup — the ConfigWarnings indicate this case.
+func PersistConfigs() error {
+	if err := atomicWriteYAML("stacks.yaml", Configs.StackConfigs); err != nil {
+		return err
+	}
+	if err := atomicWriteYAML("repos.yaml", Configs.RepoConfigs); err != nil {
+		return err
+	}
+	return nil
+}
+
+// atomicWriteYAML marshals data to YAML and writes it atomically by writing
+// to a temp file first, then renaming.
+func atomicWriteYAML(filePath string, data interface{}) error {
+	b, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", filePath, err)
+	}
+	tmp := filePath + ".tmp"
+	if err := os.WriteFile(tmp, b, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, filePath); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to rename %s to %s: %w", tmp, filePath, err)
+	}
+	return nil
 }
 
 func readConfig() (err error) {

--- a/util/config.go
+++ b/util/config.go
@@ -3,9 +3,25 @@ package util
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/spf13/viper"
 )
+
+// ConfigConflict records whether stacks/repos are defined inline in
+// config.yaml (which prevents API persistence from working) and whether
+// the corresponding split files also exist on disk.
+type ConfigConflict struct {
+	StacksInline     bool
+	ReposInline      bool
+	StacksFileExists bool
+	ReposFileExists  bool
+}
+
+// Conflict is populated during LoadConfigs and reflects the inline vs.
+// split-file state detected at startup.
+var Conflict ConfigConflict
 
 type StackConfig struct {
 	Repo                 string
@@ -41,6 +57,10 @@ func LoadConfigs() (err error) {
 	if err != nil {
 		return fmt.Errorf("could not read configuration file: %w", err)
 	}
+
+	// Detect inline config conflicts and check for split files on disk.
+	Conflict = detectConflicts()
+
 	if Configs.RepoConfigs == nil {
 		err = readRepoConfigs()
 		if err != nil {
@@ -53,7 +73,65 @@ func LoadConfigs() (err error) {
 			return fmt.Errorf("could not load stacks file: %w", err)
 		}
 	}
+
+	// Emit startup log warnings for detected conflicts.
+	logConfigWarnings(Logger)
+
 	return
+}
+
+// detectConflicts checks whether stacks/repos were loaded inline from
+// config.yaml and whether the corresponding split files exist on disk.
+func detectConflicts() ConfigConflict {
+	c := ConfigConflict{
+		StacksInline: Configs.StackConfigs != nil,
+		ReposInline:  Configs.RepoConfigs != nil,
+	}
+	if _, err := os.Stat("stacks.yaml"); err == nil {
+		c.StacksFileExists = true
+	}
+	if _, err := os.Stat("repos.yaml"); err == nil {
+		c.ReposFileExists = true
+	}
+	return c
+}
+
+// ConfigWarnings returns human-readable warning strings based on the
+// current ConfigConflict state. The returned slice is empty when no
+// conflicts exist.
+func ConfigWarnings() []string {
+	return configWarnings(Conflict)
+}
+
+func configWarnings(c ConfigConflict) []string {
+	var warnings []string
+
+	if c.StacksInline {
+		if c.StacksFileExists {
+			warnings = append(warnings, "stacks.yaml is ignored because stacks are defined in config.yaml")
+		} else {
+			warnings = append(warnings, "API changes to stacks won't persist across restarts")
+		}
+	}
+
+	if c.ReposInline {
+		if c.ReposFileExists {
+			warnings = append(warnings, "repos.yaml is ignored because repos are defined in config.yaml")
+		} else {
+			warnings = append(warnings, "API changes to repos won't persist across restarts")
+		}
+	}
+
+	return warnings
+}
+
+func logConfigWarnings(log *slog.Logger) {
+	if log == nil {
+		return
+	}
+	for _, w := range ConfigWarnings() {
+		log.Warn(w)
+	}
 }
 
 func readConfig() (err error) {

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -6,6 +6,132 @@ import (
 	"testing"
 )
 
+// ---------- PersistConfigs tests ----------
+
+func TestPersistConfigs_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	defer func() { Configs = origConfigs }()
+
+	Configs.StackConfigs = map[string]*StackConfig{
+		"my-stack": {
+			Repo:        "my-repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	}
+	Configs.RepoConfigs = map[string]*RepoConfig{
+		"my-repo": {
+			Url: "https://example.com/repo",
+		},
+	}
+
+	if err := PersistConfigs(); err != nil {
+		t.Fatalf("PersistConfigs: %v", err)
+	}
+
+	if _, err := os.Stat("stacks.yaml"); err != nil {
+		t.Fatalf("stacks.yaml not created: %v", err)
+	}
+	if _, err := os.Stat("repos.yaml"); err != nil {
+		t.Fatalf("repos.yaml not created: %v", err)
+	}
+
+	stacksData, err := os.ReadFile("stacks.yaml")
+	if err != nil {
+		t.Fatalf("read stacks.yaml: %v", err)
+	}
+	if !strings.Contains(string(stacksData), "my-stack") {
+		t.Errorf("stacks.yaml missing 'my-stack': %s", stacksData)
+	}
+	if !strings.Contains(string(stacksData), "docker-compose.yaml") {
+		t.Errorf("stacks.yaml missing compose_file: %s", stacksData)
+	}
+
+	reposData, err := os.ReadFile("repos.yaml")
+	if err != nil {
+		t.Fatalf("read repos.yaml: %v", err)
+	}
+	if !strings.Contains(string(reposData), "my-repo") {
+		t.Errorf("repos.yaml missing 'my-repo': %s", reposData)
+	}
+	if !strings.Contains(string(reposData), "https://example.com/repo") {
+		t.Errorf("repos.yaml missing url: %s", reposData)
+	}
+}
+
+func TestPersistConfigs_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	defer func() { Configs = origConfigs }()
+
+	Configs.StackConfigs = map[string]*StackConfig{
+		"test-stack": {Repo: "test-repo", Branch: "main"},
+	}
+	Configs.RepoConfigs = map[string]*RepoConfig{
+		"test-repo": {Url: "https://example.com/test"},
+	}
+
+	if err := PersistConfigs(); err != nil {
+		t.Fatalf("PersistConfigs: %v", err)
+	}
+
+	// Verify no temp files left behind
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestPersistConfigs_OmitsEmptyFields(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	defer func() { Configs = origConfigs }()
+
+	Configs.StackConfigs = map[string]*StackConfig{
+		"my-stack": {
+			Repo:   "my-repo",
+			Branch: "main",
+			// Tag, ComposeFile, etc. are empty — should be omitted
+		},
+	}
+	Configs.RepoConfigs = map[string]*RepoConfig{
+		"my-repo": {Url: "https://example.com/repo"},
+	}
+
+	if err := PersistConfigs(); err != nil {
+		t.Fatalf("PersistConfigs: %v", err)
+	}
+
+	data, _ := os.ReadFile("stacks.yaml")
+	if strings.Contains(string(data), "compose_file") {
+		t.Errorf("expected empty compose_file to be omitted: %s", data)
+	}
+	if strings.Contains(string(data), "tag") {
+		t.Errorf("expected empty tag to be omitted: %s", data)
+	}
+}
+
 // ---------- Config conflict detection tests ----------
 
 // TestConfigConflict_InlineStacksNoFile verifies that when stacks are

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,280 @@
+package util
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// ---------- Config conflict detection tests ----------
+
+// TestConfigConflict_InlineStacksNoFile verifies that when stacks are
+// defined inline in config.yaml and no stacks.yaml exists on disk,
+// the conflict is detected and the "won't persist" warning is emitted.
+func TestConfigConflict_InlineStacksNoFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+stacks:
+  my-stack:
+    repo: my-repo
+    branch: main
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.StacksInline {
+		t.Error("expected StacksInline=true")
+	}
+	if Conflict.StacksFileExists {
+		t.Error("expected StacksFileExists=false")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "API changes to stacks won't persist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'won't persist' warning for stacks, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineStacksWithFile verifies that when stacks are
+// defined inline in config.yaml AND stacks.yaml also exists on disk,
+// the "ignored" warning is emitted.
+func TestConfigConflict_InlineStacksWithFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+stacks:
+  my-stack:
+    repo: my-repo
+    branch: main
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("other-stack:\n  repo: other\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.StacksInline {
+		t.Error("expected StacksInline=true")
+	}
+	if !Conflict.StacksFileExists {
+		t.Error("expected StacksFileExists=true")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "stacks.yaml is ignored") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'stacks.yaml is ignored' warning, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_SplitOnly verifies that when stacks are only in
+// stacks.yaml (not inline), no conflict is detected.
+func TestConfigConflict_SplitOnly(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+update_interval: 60
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("my-repo:\n  url: https://example.com/repo\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if Conflict.StacksInline {
+		t.Error("expected StacksInline=false")
+	}
+	if Conflict.ReposInline {
+		t.Error("expected ReposInline=false")
+	}
+
+	warnings := ConfigWarnings()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for split-only config, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineReposNoFile verifies that when repos are
+// defined inline in config.yaml and no repos.yaml exists on disk,
+// the "won't persist" warning is emitted.
+func TestConfigConflict_InlineReposNoFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+repos:
+  my-repo:
+    url: https://example.com/repo
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.ReposInline {
+		t.Error("expected ReposInline=true")
+	}
+	if Conflict.ReposFileExists {
+		t.Error("expected ReposFileExists=false")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "API changes to repos won't persist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'won't persist' warning for repos, got %v", warnings)
+	}
+}
+
+// TestConfigConflict_InlineReposWithFile verifies that when repos are
+// defined inline AND repos.yaml exists, the "ignored" warning is emitted.
+func TestConfigConflict_InlineReposWithFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	origConfigs := Configs
+	origConflict := Conflict
+	defer func() {
+		Configs = origConfigs
+		Conflict = origConflict
+	}()
+
+	cfgYAML := `
+repos:
+  my-repo:
+    url: https://example.com/repo
+`
+	if err := os.WriteFile("config.yaml", []byte(cfgYAML), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	if err := os.WriteFile("repos.yaml", []byte("other-repo:\n  url: https://other.com\n"), 0644); err != nil {
+		t.Fatalf("write repos.yaml: %v", err)
+	}
+	if err := os.WriteFile("stacks.yaml", []byte("my-stack:\n  repo: my-repo\n  branch: main\n"), 0644); err != nil {
+		t.Fatalf("write stacks.yaml: %v", err)
+	}
+
+	Configs = Config{}
+	if err := LoadConfigs(); err != nil {
+		t.Fatalf("LoadConfigs: %v", err)
+	}
+
+	if !Conflict.ReposInline {
+		t.Error("expected ReposInline=true")
+	}
+	if !Conflict.ReposFileExists {
+		t.Error("expected ReposFileExists=true")
+	}
+
+	warnings := ConfigWarnings()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "repos.yaml is ignored") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'repos.yaml is ignored' warning, got %v", warnings)
+	}
+}

--- a/web/auth.go
+++ b/web/auth.go
@@ -1,0 +1,60 @@
+package web
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+var apiToken string
+
+func init() {
+	apiToken = os.Getenv("SWARMCD_API_TOKEN")
+}
+
+// MutationAPIEnabled reports whether the mutation API is active.
+// The mutation API requires a bearer token set via SWARMCD_API_TOKEN.
+func MutationAPIEnabled() bool {
+	return apiToken != ""
+}
+
+// authMiddleware returns a Gin handler that enforces bearer token auth.
+// If no token is configured, all mutation requests are rejected with 403.
+func authMiddleware() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if !MutationAPIEnabled() {
+			ctx.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error": "mutation API is disabled (SWARMCD_API_TOKEN not set)",
+			})
+			return
+		}
+
+		header := ctx.GetHeader("Authorization")
+		if header == "" {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "missing Authorization header",
+			})
+			return
+		}
+
+		if !strings.HasPrefix(header, "Bearer ") {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "invalid Authorization header format (expected 'Bearer <token>')",
+			})
+			return
+		}
+
+		token := strings.TrimPrefix(header, "Bearer ")
+		if subtle.ConstantTimeCompare([]byte(token), []byte(apiToken)) != 1 {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "invalid token",
+			})
+			return
+		}
+
+		ctx.Next()
+	}
+}

--- a/web/auth_test.go
+++ b/web/auth_test.go
@@ -1,0 +1,133 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newTestRouter creates a minimal router with auth middleware for testing.
+func newTestRouter(handler gin.HandlerFunc) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	write := r.Group("/")
+	write.Use(authMiddleware())
+	write.POST("/test", handler)
+	return r
+}
+
+func TestAuth_NoTokenConfigured(t *testing.T) {
+	oldToken := apiToken
+	apiToken = ""
+	defer func() { apiToken = oldToken }()
+
+	r := newTestRouter(func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	if body["error"] == nil {
+		t.Error("expected error in response")
+	}
+}
+
+func TestAuth_MissingHeader(t *testing.T) {
+	oldToken := apiToken
+	apiToken = "test-secret"
+	defer func() { apiToken = oldToken }()
+
+	r := newTestRouter(func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_InvalidFormat(t *testing.T) {
+	oldToken := apiToken
+	apiToken = "test-secret"
+	defer func() { apiToken = oldToken }()
+
+	r := newTestRouter(func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_WrongToken(t *testing.T) {
+	oldToken := apiToken
+	apiToken = "correct-token"
+	defer func() { apiToken = oldToken }()
+
+	r := newTestRouter(func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAuth_ValidToken(t *testing.T) {
+	oldToken := apiToken
+	apiToken = "correct-token"
+	defer func() { apiToken = oldToken }()
+
+	r := newTestRouter(func(ctx *gin.Context) {
+		ctx.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req.Header.Set("Authorization", "Bearer correct-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestAuth_MutationAPIEnabled(t *testing.T) {
+	oldToken := apiToken
+	defer func() { apiToken = oldToken }()
+
+	apiToken = ""
+	if MutationAPIEnabled() {
+		t.Error("expected MutationAPIEnabled=false when token is empty")
+	}
+
+	apiToken = "some-token"
+	if !MutationAPIEnabled() {
+		t.Error("expected MutationAPIEnabled=true when token is set")
+	}
+}

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -13,10 +13,11 @@ func getStacks(ctx *gin.Context) {
 	var stacks []map[string]string
 	for k, v := range stacksStatus {
 		stacks = append(stacks, map[string]string{
-			"Name": k,
-			"Error": v.Error,
-			"RepoURL": v.RepoURL,
+			"Name":     k,
+			"Error":    v.Error,
+			"RepoURL":  v.RepoURL,
 			"Revision": v.Revision,
+			"Ref":      v.Ref,
 		})
 	}
 	sort.Slice(stacks, func(i, j int) bool {

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -1,27 +1,91 @@
 package web
 
 import (
+	"fmt"
+	"math"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/m-adawi/swarm-cd/swarmcd"
+	"github.com/m-adawi/swarm-cd/util"
 )
+
+type stackResponse struct {
+	Name           string     `json:"name"`
+	RepoURL        string     `json:"repo_url"`
+	RefType        string     `json:"ref_type"`
+	RefValue       string     `json:"ref_value"`
+	Revision       string     `json:"revision"`
+	ComposeFile    string     `json:"compose_file"`
+	Error          string     `json:"error"`
+	LastChangeAt   *time.Time `json:"last_change_at"`
+	LastDeployedAt *time.Time `json:"last_deployed_at"`
+}
+
+func getHealth(ctx *gin.Context) {
+	info := swarmcd.GetRuntimeInfo()
+	stacksStatus := swarmcd.GetStackStatus()
+	uptime := time.Since(info.BootedAt).Seconds()
+
+	resp := gin.H{
+		"status":                  "healthy",
+		"booted_at":               info.BootedAt,
+		"version":                 info.Version,
+		"uptime_seconds":          math.Floor(uptime),
+		"update_interval_seconds": util.Configs.UpdateInterval,
+		"stacks_managed":          len(stacksStatus),
+	}
+
+	if warnings := util.ConfigWarnings(); len(warnings) > 0 {
+		resp["config_warnings"] = warnings
+	}
+
+	ctx.JSON(http.StatusOK, resp)
+}
+
+func getStack(ctx *gin.Context) {
+	name := ctx.Param("name")
+	stacksStatus := swarmcd.GetStackStatus()
+	v, ok := stacksStatus[name]
+	if !ok {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("stack '%s' not found", name),
+		})
+		return
+	}
+	ctx.JSON(http.StatusOK, stackResponse{
+		Name:           name,
+		RepoURL:        v.RepoURL,
+		RefType:        v.RefType,
+		RefValue:       v.RefValue,
+		Revision:       v.Revision,
+		ComposeFile:    v.ComposeFile,
+		Error:          v.Error,
+		LastChangeAt:   v.LastChangeAt,
+		LastDeployedAt: v.LastDeployedAt,
+	})
+}
 
 func getStacks(ctx *gin.Context) {
 	stacksStatus := swarmcd.GetStackStatus()
-	var stacks []map[string]string
+	var stacks []stackResponse
 	for k, v := range stacksStatus {
-		stacks = append(stacks, map[string]string{
-			"Name":     k,
-			"Error":    v.Error,
-			"RepoURL":  v.RepoURL,
-			"Revision": v.Revision,
-			"Ref":      v.Ref,
+		stacks = append(stacks, stackResponse{
+			Name:           k,
+			RepoURL:        v.RepoURL,
+			RefType:        v.RefType,
+			RefValue:       v.RefValue,
+			Revision:       v.Revision,
+			ComposeFile:    v.ComposeFile,
+			Error:          v.Error,
+			LastChangeAt:   v.LastChangeAt,
+			LastDeployedAt: v.LastDeployedAt,
 		})
 	}
 	sort.Slice(stacks, func(i, j int) bool {
-		return stacks[i]["Name"] < stacks[j]["Name"]
+		return stacks[i].Name < stacks[j].Name
 	})
 	ctx.JSON(http.StatusOK, stacks)
 }

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -36,6 +37,7 @@ func getHealth(ctx *gin.Context) {
 		"uptime_seconds":          math.Floor(uptime),
 		"update_interval_seconds": util.Configs.UpdateInterval,
 		"stacks_managed":          len(stacksStatus),
+		"mutation_api_enabled":    MutationAPIEnabled(),
 	}
 
 	if warnings := util.ConfigWarnings(); len(warnings) > 0 {
@@ -66,6 +68,34 @@ func getStack(ctx *gin.Context) {
 		LastChangeAt:   v.LastChangeAt,
 		LastDeployedAt: v.LastDeployedAt,
 	})
+}
+
+func patchStack(ctx *gin.Context) {
+	name := ctx.Param("name")
+
+	var req swarmcd.PatchRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("invalid request body: %v", err),
+		})
+		return
+	}
+
+	resp, err := swarmcd.PatchStack(name, req)
+	if err != nil {
+		var validationErr *swarmcd.ValidationError
+		var notFoundErr *swarmcd.NotFoundError
+		if errors.As(err, &validationErr) {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": validationErr.Message})
+		} else if errors.As(err, &notFoundErr) {
+			ctx.JSON(http.StatusNotFound, gin.H{"error": notFoundErr.Message})
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, resp)
 }
 
 func getStacks(ctx *gin.Context) {

--- a/web/controllers_test.go
+++ b/web/controllers_test.go
@@ -1,0 +1,466 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/m-adawi/swarm-cd/swarmcd"
+	"github.com/m-adawi/swarm-cd/util"
+)
+
+// setupTestStacks populates the swarmcd package-level state with test data
+// and returns a cleanup function to restore the original state.
+func setupTestStacks(t *testing.T, data map[string]*swarmcd.StackStatus) func() {
+	t.Helper()
+	return swarmcd.SetStackStatusForTest(data)
+}
+
+// decodeBody is a test helper that decodes a JSON response body into a map.
+func decodeBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	return body
+}
+
+func TestGetStacks_ReturnsAllFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().Truncate(time.Second)
+	earlier := now.Add(-1 * time.Hour)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"my-stack": {
+			Error:          "some error",
+			Revision:       "abc12345",
+			RepoURL:        "https://github.com/example/repo",
+			RefType:        "branch",
+			RefValue:       "main",
+			ComposeFile:    "docker-compose.yaml",
+			LastChangeAt:   &earlier,
+			LastDeployedAt: &now,
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks", getStacks)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var stacks []stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &stacks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+
+	s := stacks[0]
+
+	if s.Name != "my-stack" {
+		t.Errorf("expected name %q, got %q", "my-stack", s.Name)
+	}
+	if s.RepoURL != "https://github.com/example/repo" {
+		t.Errorf("expected repo_url %q, got %q", "https://github.com/example/repo", s.RepoURL)
+	}
+	if s.RefType != "branch" {
+		t.Errorf("expected ref_type %q, got %q", "branch", s.RefType)
+	}
+	if s.RefValue != "main" {
+		t.Errorf("expected ref_value %q, got %q", "main", s.RefValue)
+	}
+	if s.Revision != "abc12345" {
+		t.Errorf("expected revision %q, got %q", "abc12345", s.Revision)
+	}
+	if s.ComposeFile != "docker-compose.yaml" {
+		t.Errorf("expected compose_file %q, got %q", "docker-compose.yaml", s.ComposeFile)
+	}
+	if s.Error != "some error" {
+		t.Errorf("expected error %q, got %q", "some error", s.Error)
+	}
+	if s.LastChangeAt == nil {
+		t.Fatal("expected last_change_at to be non-nil")
+	}
+	if !s.LastChangeAt.Equal(earlier) {
+		t.Errorf("expected last_change_at %v, got %v", earlier, *s.LastChangeAt)
+	}
+	if s.LastDeployedAt == nil {
+		t.Fatal("expected last_deployed_at to be non-nil")
+	}
+	if !s.LastDeployedAt.Equal(now) {
+		t.Errorf("expected last_deployed_at %v, got %v", now, *s.LastDeployedAt)
+	}
+
+	// Verify JSON field names are snake_case by checking raw JSON
+	var raw []map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("failed to decode raw response: %v", err)
+	}
+	expectedKeys := []string{"name", "repo_url", "ref_type", "ref_value", "revision", "compose_file", "error", "last_change_at", "last_deployed_at"}
+	for _, key := range expectedKeys {
+		if _, ok := raw[0][key]; !ok {
+			t.Errorf("expected JSON key %q not found in response", key)
+		}
+	}
+}
+
+func TestGetStacks_SortOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"charlie": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "main",
+		},
+		"alpha": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "tag",
+			RefValue: "v1.0.0",
+		},
+		"bravo": {
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "develop",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks", getStacks)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var stacks []stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &stacks); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(stacks) != 3 {
+		t.Fatalf("expected 3 stacks, got %d", len(stacks))
+	}
+
+	expectedOrder := []string{"alpha", "bravo", "charlie"}
+	for i, expected := range expectedOrder {
+		if stacks[i].Name != expected {
+			t.Errorf("position %d: expected %q, got %q", i, expected, stacks[i].Name)
+		}
+	}
+}
+
+// ---------- GET /stacks/:name tests ----------
+
+func TestGetStackByName_Found(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	now := time.Now().Truncate(time.Second)
+	earlier := now.Add(-1 * time.Hour)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"my-stack": {
+			Error:          "",
+			Revision:       "abc12345",
+			RepoURL:        "https://github.com/example/repo",
+			RefType:        "branch",
+			RefValue:       "main",
+			ComposeFile:    "docker-compose.yaml",
+			LastChangeAt:   &earlier,
+			LastDeployedAt: &now,
+		},
+		"other-stack": {
+			Revision: "def67890",
+			RepoURL:  "https://github.com/example/other",
+			RefType:  "tag",
+			RefValue: "v1.0.0",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks/:name", getStack)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks/my-stack", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var s stackResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if s.Name != "my-stack" {
+		t.Errorf("expected name %q, got %q", "my-stack", s.Name)
+	}
+	if s.RepoURL != "https://github.com/example/repo" {
+		t.Errorf("expected repo_url %q, got %q", "https://github.com/example/repo", s.RepoURL)
+	}
+	if s.RefType != "branch" {
+		t.Errorf("expected ref_type %q, got %q", "branch", s.RefType)
+	}
+	if s.RefValue != "main" {
+		t.Errorf("expected ref_value %q, got %q", "main", s.RefValue)
+	}
+}
+
+func TestGetStackByName_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cleanup := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"existing-stack": {
+			Revision: "abc12345",
+			RepoURL:  "https://github.com/example/repo",
+			RefType:  "branch",
+			RefValue: "main",
+		},
+	})
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/stacks/:name", getStack)
+
+	req := httptest.NewRequest(http.MethodGet, "/stacks/foo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	expected := "stack 'foo' not found"
+	if body["error"] != expected {
+		t.Errorf("expected error %q, got %q", expected, body["error"])
+	}
+}
+
+// ---------- GET /health tests ----------
+
+func TestGetHealth_ReturnsBootTime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if body["status"] != "healthy" {
+		t.Errorf("expected status %q, got %q", "healthy", body["status"])
+	}
+
+	// Verify booted_at is present and parseable
+	bootedAtStr, ok := body["booted_at"].(string)
+	if !ok {
+		t.Fatalf("expected booted_at to be a string, got %T", body["booted_at"])
+	}
+	parsedBoot, err := time.Parse(time.RFC3339Nano, bootedAtStr)
+	if err != nil {
+		t.Fatalf("failed to parse booted_at %q: %v", bootedAtStr, err)
+	}
+	if !parsedBoot.Equal(bootedAt) {
+		t.Errorf("expected booted_at %v, got %v", bootedAt, parsedBoot)
+	}
+
+	// Verify uptime is positive
+	uptimeRaw, ok := body["uptime_seconds"].(float64)
+	if !ok {
+		t.Fatalf("expected uptime_seconds to be a number, got %T", body["uptime_seconds"])
+	}
+	if uptimeRaw <= 0 {
+		t.Errorf("expected positive uptime_seconds, got %v", uptimeRaw)
+	}
+
+	if body["version"] != "dev" {
+		t.Errorf("expected version %q, got %q", "dev", body["version"])
+	}
+
+	if body["update_interval_seconds"] != float64(120) {
+		t.Errorf("expected update_interval_seconds=120, got %v", body["update_interval_seconds"])
+	}
+}
+
+func TestGetHealth_ReturnsStackCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "1.2.3",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{
+		"stack-a": {Revision: "aaa", RepoURL: "https://github.com/a"},
+		"stack-b": {Revision: "bbb", RepoURL: "https://github.com/b"},
+		"stack-c": {Revision: "ccc", RepoURL: "https://github.com/c"},
+	})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 60
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if body["stacks_managed"] != float64(3) {
+		t.Errorf("expected stacks_managed=3, got %v", body["stacks_managed"])
+	}
+
+	if body["version"] != "1.2.3" {
+		t.Errorf("expected version %q, got %q", "1.2.3", body["version"])
+	}
+}
+
+// ---------- GET /health config_warnings tests ----------
+
+func TestGetHealth_ReturnsConfigWarnings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	// Simulate inline config conflict (stacks inline, no split file)
+	oldConflict := util.Conflict
+	util.Conflict = util.ConfigConflict{
+		StacksInline:     true,
+		ReposInline:      false,
+		StacksFileExists: false,
+		ReposFileExists:  false,
+	}
+	defer func() { util.Conflict = oldConflict }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	rawWarnings, ok := body["config_warnings"]
+	if !ok {
+		t.Fatal("expected config_warnings key in health response")
+	}
+	warnings, ok := rawWarnings.([]interface{})
+	if !ok {
+		t.Fatalf("expected config_warnings to be an array, got %T", rawWarnings)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if warnings[0] != "API changes to stacks won't persist across restarts" {
+		t.Errorf("unexpected warning: %v", warnings[0])
+	}
+}
+
+func TestGetHealth_NoConfigWarnings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bootedAt := time.Now().Add(-1 * time.Minute)
+	cleanupRuntime := swarmcd.SetRuntimeInfoForTest(swarmcd.RuntimeInfo{
+		BootedAt: bootedAt,
+		Version:  "dev",
+	})
+	defer cleanupRuntime()
+
+	cleanupStacks := setupTestStacks(t, map[string]*swarmcd.StackStatus{})
+	defer cleanupStacks()
+
+	oldInterval := util.Configs.UpdateInterval
+	util.Configs.UpdateInterval = 120
+	defer func() { util.Configs.UpdateInterval = oldInterval }()
+
+	// No conflicts — split config only
+	oldConflict := util.Conflict
+	util.Conflict = util.ConfigConflict{}
+	defer func() { util.Conflict = oldConflict }()
+
+	r := gin.New()
+	r.GET("/health", getHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+
+	if _, ok := body["config_warnings"]; ok {
+		t.Error("expected no config_warnings key when there are no conflicts")
+	}
+}

--- a/web/patch_test.go
+++ b/web/patch_test.go
@@ -1,0 +1,565 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/m-adawi/swarm-cd/swarmcd"
+)
+
+// chdirTemp changes to a temp directory for the duration of the test.
+// This isolates PersistConfigs file writes.
+func chdirTemp(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+// createTestGitRepo creates a bare git repo with a single commit containing
+// a docker-compose.yaml file. Returns the bare repo path (usable as URL).
+func createTestGitRepo(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	repoDir := filepath.Join(dir, name+".git")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Init bare repo with main as default branch
+	gitRun(t, repoDir, "git", "init", "--bare")
+	gitRun(t, repoDir, "git", "symbolic-ref", "HEAD", "refs/heads/main")
+
+	// Create work dir, init, add content, push
+	workDir := filepath.Join(dir, name+"-work")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("mkdir work: %v", err)
+	}
+
+	gitRun(t, workDir, "git", "init")
+	gitRun(t, workDir, "git", "config", "user.email", "test@test.com")
+	gitRun(t, workDir, "git", "config", "user.name", "test")
+	gitRun(t, workDir, "git", "checkout", "-b", "main")
+
+	composeContent := "version: '3'\nservices:\n  web:\n    image: nginx\n"
+	if err := os.WriteFile(filepath.Join(workDir, "docker-compose.yaml"), []byte(composeContent), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+
+	gitRun(t, workDir, "git", "add", ".")
+	gitRun(t, workDir, "git", "commit", "-m", "initial")
+	gitRun(t, workDir, "git", "remote", "add", "origin", repoDir)
+	gitRun(t, workDir, "git", "push", "-u", "origin", "main")
+
+	return repoDir
+}
+
+func gitRun(t *testing.T, dir, command string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(command, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command %q in %s failed: %v\n%s", command+" "+strings.Join(args, " "), dir, err, out)
+	}
+}
+
+func setupPatchRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.PATCH("/stacks/:name", patchStack)
+	return r
+}
+
+func TestPatchStack_UpdateRef(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "develop"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["my-stack"].RefType != "branch" {
+		t.Errorf("expected ref_type 'branch', got %q", status["my-stack"].RefType)
+	}
+	if status["my-stack"].RefValue != "develop" {
+		t.Errorf("expected ref_value 'develop', got %q", status["my-stack"].RefValue)
+	}
+}
+
+func TestPatchStack_BranchToTag(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"tag": "v1.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["my-stack"].RefType != "tag" {
+		t.Errorf("expected ref_type 'tag', got %q", status["my-stack"].RefType)
+	}
+	if status["my-stack"].RefValue != "v1.0.0" {
+		t.Errorf("expected ref_value 'v1.0.0', got %q", status["my-stack"].RefValue)
+	}
+}
+
+func TestPatchStack_TagToBranch(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Tag:         "v1.0.0",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "main"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["my-stack"].RefType != "branch" {
+		t.Errorf("expected ref_type 'branch', got %q", status["my-stack"].RefType)
+	}
+	if status["my-stack"].RefValue != "main" {
+		t.Errorf("expected ref_value 'main', got %q", status["my-stack"].RefValue)
+	}
+}
+
+func TestPatchStack_RejectsEmpty(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPatchStack_RejectsBothBranchAndTag(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "develop", "tag": "v1.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPatchStack_NotFound(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "develop"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/missing", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPatchStack_ComposeFile(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"compose_file": "docker-compose.prod.yaml"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["my-stack"].ComposeFile != "docker-compose.prod.yaml" {
+		t.Errorf("expected compose_file 'docker-compose.prod.yaml', got %q", status["my-stack"].ComposeFile)
+	}
+}
+
+func TestPatchStack_PartialUpdate(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"compose_file": "docker-compose.staging.yaml"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	// branch should be unchanged
+	if status["my-stack"].RefType != "branch" {
+		t.Errorf("expected ref_type 'branch', got %q", status["my-stack"].RefType)
+	}
+	if status["my-stack"].RefValue != "main" {
+		t.Errorf("expected ref_value 'main', got %q", status["my-stack"].RefValue)
+	}
+	// compose_file should be updated
+	if status["my-stack"].ComposeFile != "docker-compose.staging.yaml" {
+		t.Errorf("expected compose_file 'docker-compose.staging.yaml', got %q", status["my-stack"].ComposeFile)
+	}
+}
+
+func TestPatchStack_UpdateRepoURL(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Change to tmpDir so PersistConfigs writes there
+	orig, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	// Create two test git repos
+	repoPath1 := createTestGitRepo(t, tmpDir, "repo1")
+	repoPath2 := createTestGitRepo(t, tmpDir, "repo2")
+
+	// Clone repo1 to simulate the existing working copy
+	workDir := filepath.Join(tmpDir, "repos", "my-repo")
+	if err := os.MkdirAll(filepath.Dir(workDir), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	gitRun(t, tmpDir, "git", "clone", repoPath1, workDir)
+
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    workDir,
+			RepoURL:     repoPath1,
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body, _ := json.Marshal(map[string]string{"repo_url": repoPath2})
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["my-stack"].RepoURL != repoPath2 {
+		t.Errorf("expected repo_url %q, got %q", repoPath2, status["my-stack"].RepoURL)
+	}
+}
+
+func TestPatchStack_SharedRepo_BranchIsolation(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "stack-a",
+			RepoName:    "shared-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+		{
+			Name:        "stack-b",
+			RepoName:    "shared-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "develop",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "feature"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/stack-a", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	status := swarmcd.GetStackStatus()
+	if status["stack-a"].RefValue != "feature" {
+		t.Errorf("expected ref_value 'feature', got %q", status["stack-a"].RefValue)
+	}
+	if status["stack-b"].RefValue != "develop" {
+		t.Errorf("expected stack-b ref_value 'develop', got %q", status["stack-b"].RefValue)
+	}
+}
+
+func TestPatchStack_SharedRepo_URLChangeWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	repoPath1 := createTestGitRepo(t, tmpDir, "shared")
+	repoPath2 := createTestGitRepo(t, tmpDir, "new-origin")
+
+	workDir := filepath.Join(tmpDir, "repos", "shared-repo")
+	if err := os.MkdirAll(filepath.Dir(workDir), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	gitRun(t, tmpDir, "git", "clone", repoPath1, workDir)
+
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "stack-a",
+			RepoName:    "shared-repo",
+			RepoPath:    workDir,
+			RepoURL:     repoPath1,
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+		{
+			Name:        "stack-b",
+			RepoName:    "shared-repo",
+			RepoPath:    workDir,
+			RepoURL:     repoPath1,
+			Branch:      "develop",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body, _ := json.Marshal(map[string]string{"repo_url": repoPath2})
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/stack-a", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the response contains a shared-repo warning
+	var resp swarmcd.PatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Warnings) == 0 {
+		t.Fatal("expected warnings about shared repo, got none")
+	}
+
+	found := false
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "shared-repo") && strings.Contains(w, "stack-b") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning mentioning shared-repo and stack-b, got: %v", resp.Warnings)
+	}
+}
+
+func TestPatchStack_NoAuth(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	oldToken := apiToken
+	apiToken = "test-secret"
+	defer func() { apiToken = oldToken }()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	write := r.Group("/")
+	write.Use(authMiddleware())
+	write.PATCH("/stacks/:name", patchStack)
+
+	body := `{"branch": "develop"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPatchStack_AtomicPersistence(t *testing.T) {
+	chdirTemp(t)
+	cleanup := swarmcd.SetFullStateForTest([]swarmcd.TestStackDef{
+		{
+			Name:        "my-stack",
+			RepoName:    "my-repo",
+			RepoPath:    "/tmp/fake-repo",
+			RepoURL:     "https://example.com/repo",
+			Branch:      "main",
+			ComposeFile: "docker-compose.yaml",
+		},
+	})
+	defer cleanup()
+
+	r := setupPatchRouter(t)
+	body := `{"branch": "develop"}`
+	req := httptest.NewRequest(http.MethodPatch, "/stacks/my-stack", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify stacks.yaml was written
+	data, err := os.ReadFile("stacks.yaml")
+	if err != nil {
+		t.Fatalf("expected stacks.yaml to exist: %v", err)
+	}
+	if !strings.Contains(string(data), "develop") {
+		t.Errorf("expected stacks.yaml to contain 'develop': %s", data)
+	}
+
+	// Verify no .tmp files left behind
+	entries, _ := os.ReadDir(".")
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}

--- a/web/restart.go
+++ b/web/restart.go
@@ -1,0 +1,127 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/gin-gonic/gin"
+	"github.com/m-adawi/swarm-cd/swarmcd"
+)
+
+func restartStack(ctx *gin.Context) {
+	name := ctx.Param("name")
+	if !swarmcd.StackExists(name) {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("stack '%s' not found", name),
+		})
+		return
+	}
+
+	api := swarmcd.GetDockerServiceAPI()
+	count, err := forceUpdateServices(api, name, "")
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to restart stack '%s': %v", name, err),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message":            fmt.Sprintf("restarted %d service(s) in stack '%s'", count, name),
+		"services_restarted": count,
+	})
+}
+
+func restartService(ctx *gin.Context) {
+	stackName := ctx.Param("name")
+	serviceName := ctx.Param("service")
+
+	if !swarmcd.StackExists(stackName) {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("stack '%s' not found", stackName),
+		})
+		return
+	}
+
+	api := swarmcd.GetDockerServiceAPI()
+	count, err := forceUpdateServices(api, stackName, serviceName)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("failed to restart service '%s' in stack '%s': %v", serviceName, stackName, err),
+		})
+		return
+	}
+
+	if count == 0 {
+		ctx.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("no service matching '%s' found in stack '%s'", serviceName, stackName),
+		})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message":            fmt.Sprintf("restarted service '%s' in stack '%s'", serviceName, stackName),
+		"services_restarted": count,
+	})
+}
+
+func restartAll(ctx *gin.Context) {
+	api := swarmcd.GetDockerServiceAPI()
+	names := swarmcd.GetStackNames()
+
+	total := 0
+	for _, name := range names {
+		count, err := forceUpdateServices(api, name, "")
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{
+				"error": fmt.Sprintf("failed to restart stack '%s': %v", name, err),
+			})
+			return
+		}
+		total += count
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"message":            fmt.Sprintf("restarted %d service(s) across %d stack(s)", total, len(names)),
+		"services_restarted": total,
+	})
+}
+
+// forceUpdateServices lists Docker services for the given stack and increments
+// their ForceUpdate counter, causing Docker to redeploy them. If serviceName
+// is non-empty, only services whose name starts with "<stack>_<serviceName>"
+// are restarted.
+func forceUpdateServices(api swarmcd.ServiceAPI, stackName, serviceName string) (int, error) {
+	bg := context.Background()
+
+	services, err := api.ServiceList(bg, types.ServiceListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("label", "com.docker.stack.namespace="+stackName),
+		),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	count := 0
+	for _, svc := range services {
+		if serviceName != "" {
+			prefix := stackName + "_" + serviceName
+			if !strings.HasPrefix(svc.Spec.Name, prefix) {
+				continue
+			}
+		}
+
+		svc.Spec.TaskTemplate.ForceUpdate++
+		if _, err := api.ServiceUpdate(bg, svc.ID, svc.Version, svc.Spec, types.ServiceUpdateOptions{}); err != nil {
+			return count, fmt.Errorf("failed to update service %s: %w", svc.Spec.Name, err)
+		}
+		count++
+	}
+
+	return count, nil
+}

--- a/web/restart_test.go
+++ b/web/restart_test.go
@@ -1,0 +1,220 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/gin-gonic/gin"
+	"github.com/m-adawi/swarm-cd/swarmcd"
+)
+
+type mockServiceAPI struct {
+	services  []swarm.Service
+	listErr   error
+	updateErr error
+	updates   []string // tracks which services were updated
+}
+
+func (m *mockServiceAPI) ServiceList(_ context.Context, _ types.ServiceListOptions) ([]swarm.Service, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.services, nil
+}
+
+func (m *mockServiceAPI) ServiceUpdate(_ context.Context, _ string, _ swarm.Version, spec swarm.ServiceSpec, _ types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
+	if m.updateErr != nil {
+		return swarm.ServiceUpdateResponse{}, m.updateErr
+	}
+	m.updates = append(m.updates, spec.Name)
+	return swarm.ServiceUpdateResponse{}, nil
+}
+
+func setupRestartRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/stacks/:name/restart", restartStack)
+	r.POST("/stacks/:name/services/:service/restart", restartService)
+	r.POST("/restart", restartAll)
+	return r
+}
+
+func TestRestartStack_Success(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"my-stack": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	mock := &mockServiceAPI{
+		services: []swarm.Service{
+			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_web"}}},
+			{ID: "svc2", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_worker"}}},
+		},
+	}
+	cleanupAPI := swarmcd.SetServiceAPIForTest(mock)
+	defer cleanupAPI()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/stacks/my-stack/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(mock.updates) != 2 {
+		t.Errorf("expected 2 service updates, got %d", len(mock.updates))
+	}
+}
+
+func TestRestartStack_NotFound(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{})
+	defer cleanup()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/stacks/missing/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestRestartService_Success(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"my-stack": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	mock := &mockServiceAPI{
+		services: []swarm.Service{
+			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_web"}}},
+			{ID: "svc2", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_worker"}}},
+		},
+	}
+	cleanupAPI := swarmcd.SetServiceAPIForTest(mock)
+	defer cleanupAPI()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/stacks/my-stack/services/web/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(mock.updates) != 1 {
+		t.Errorf("expected 1 service update, got %d", len(mock.updates))
+	}
+	if len(mock.updates) > 0 && mock.updates[0] != "my-stack_web" {
+		t.Errorf("expected service 'my-stack_web' to be updated, got %q", mock.updates[0])
+	}
+}
+
+func TestRestartService_NotFoundService(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"my-stack": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	mock := &mockServiceAPI{
+		services: []swarm.Service{
+			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_web"}}},
+		},
+	}
+	cleanupAPI := swarmcd.SetServiceAPIForTest(mock)
+	defer cleanupAPI()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/stacks/my-stack/services/nonexistent/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRestartAll_Success(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"stack-a": {RepoURL: "https://example.com"},
+		"stack-b": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	mock := &mockServiceAPI{
+		services: []swarm.Service{
+			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "stack-a_web"}}},
+		},
+	}
+	cleanupAPI := swarmcd.SetServiceAPIForTest(mock)
+	defer cleanupAPI()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRestartStack_AuthRequired(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"my-stack": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	oldToken := apiToken
+	apiToken = "test-secret"
+	defer func() { apiToken = oldToken }()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	write := r.Group("/")
+	write.Use(authMiddleware())
+	write.POST("/stacks/:name/restart", restartStack)
+
+	req := httptest.NewRequest(http.MethodPost, "/stacks/my-stack/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRestartStack_ServiceUpdateError(t *testing.T) {
+	cleanup := swarmcd.SetStackStatusForTest(map[string]*swarmcd.StackStatus{
+		"my-stack": {RepoURL: "https://example.com"},
+	})
+	defer cleanup()
+
+	mock := &mockServiceAPI{
+		services: []swarm.Service{
+			{ID: "svc1", Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "my-stack_web"}}},
+		},
+		updateErr: fmt.Errorf("connection refused"),
+	}
+	cleanupAPI := swarmcd.SetServiceAPIForTest(mock)
+	defer cleanupAPI()
+
+	r := setupRestartRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/stacks/my-stack/restart", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}

--- a/web/routes.go
+++ b/web/routes.go
@@ -19,6 +19,14 @@ func init() {
 	router.GET("/", func(c *gin.Context) {
 		c.Redirect(302, "/ui")
 	})
+
+	// Write API endpoints (require auth)
+	write := router.Group("/")
+	write.Use(authMiddleware())
+	write.PATCH("/stacks/:name", patchStack)
+	write.POST("/stacks/:name/restart", restartStack)
+	write.POST("/stacks/:name/services/:service/restart", restartService)
+	write.POST("/restart", restartAll)
 }
 
 func RunServer(address string) error {

--- a/web/routes.go
+++ b/web/routes.go
@@ -12,6 +12,8 @@ var router *gin.Engine = gin.New()
 func init() {
 	router.Use(sloggin.New(util.Logger))
 	router.GET("/stacks", getStacks)
+	router.GET("/stacks/:name", getStack)
+	router.GET("/health", getHealth)
 	router.StaticFile("/ui", "ui/index.html")
 	router.Static("/assets", "ui/assets")
 	router.GET("/", func(c *gin.Context) {


### PR DESCRIPTION
## Summary

Adds mutation endpoints behind bearer token auth, building on the read API from PR #157 (gamma).

**Prerequisites:** PRs #156 (concurrency fix) and #157 (read API) must merge first. This branch includes their commits so CI passes; once they merge, a rebase will shrink the diff to only delta's changes.

### What's included

| Endpoint | Purpose |
|----------|---------|
| `PATCH /stacks/:name` | Update branch/tag, compose file, or repo URL |
| `POST /stacks/:name/restart` | Force-redeploy all services in a stack |
| `POST /stacks/:name/services/:service/restart` | Restart a single service |
| `POST /restart` | Restart all managed stacks |

### Key implementation details

- **Auth**: Bearer token via `SWARMCD_API_TOKEN` env var, validated with `crypto/subtle.ConstantTimeCompare` for timing safety. Mutation API is disabled (403) when no token is set.
- **PATCH with 3-phase locking**: validate (RLock) → I/O like git clone (no locks) → apply state (Lock). This respects the existing lock ordering (`stateMu` must never be acquired while `repo.lock` is held) and prevents deadlocks with the reconciler.
- **Repo URL changes**: clone-to-temp-then-swap pattern — clone the new URL to a temp dir in the same parent (same filesystem), remove old, rename new into place. Warns when other stacks share the same repo.
- **Config persistence**: `PersistConfigs()` writes `stacks.yaml` and `repos.yaml` atomically (write `.tmp` then `os.Rename`). YAML tags added to `StackConfig`/`RepoConfig` with `omitempty` for clean output.
- **Restart**: Uses Docker Engine API's `ForceUpdate` counter via a `ServiceAPI` interface. Services are found by `com.docker.stack.namespace` label. Individual service restart matches by `<stack>_<service>` name prefix.
- **Typed errors**: `ValidationError` → 400, `NotFoundError` → 404, mapped via `errors.As()` in the handler.
- **Health endpoint**: Now includes `mutation_api_enabled` field.

### New files
- `web/auth.go` — auth middleware
- `web/restart.go` — restart controllers
- `swarmcd/patch.go` — PATCH logic, typed errors, clone-to-temp-then-swap
- `swarmcd/restart.go` — ServiceAPI interface, StackExists, GetStackNames

### Tests (27 new)
- Auth: 6 tests (no token, missing header, invalid format, wrong token, valid token, MutationAPIEnabled)
- Restart: 7 tests with `mockServiceAPI` (stack success/not-found, service success/not-found, restart-all, auth required, update error)
- PATCH: 14 tests including real git repos for URL changes (update ref, branch↔tag, empty/both rejected, not-found, compose file, partial update, repo URL swap, shared-repo warning, no-auth, atomic persistence)

Part of the REST API contribution discussed in #151.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)