### PR TITLE
feat: add multiple compose file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ Then we define the stack in `stacks.yaml`
 nginx:
   repo: swarm-cd-example
   branch: main
-  compose_file: nginx/compose.yaml
+  compose_files:
+    - nginx/compose.yaml
+    - nginx/compose.prod.yaml
 ```
+
+`compose_files` is the canonical field and supports one or more files merged in listed order
+(same behavior as multiple `-c/--compose-file` flags in `docker stack deploy`).
+`compose_file` is still accepted for backward compatibility, but cannot be used together with `compose_files`.
 
 And finally, we deploy SwarmCD to the cluster
 using the following docker-compose file:
@@ -103,12 +109,13 @@ setting the property`sops_files` in a stack defenition.
 nginx-ssl:
     repo: swarm-cd-example
     branch: main
-    compose_file: nginx-ssl/compose.yaml
-    sops_files: 
+    compose_files:
+      - nginx-ssl/compose.yaml
+    sops_files:
       - nginx-ssl/secrets/www.example.com.crt
       - nginx-ssl/secrets/www.example.com.key
-```
 
+```
 Then you need to set the SOPS environment variables that are required
 to decrypt the files.
 Depending on the backend you used for sops encryption, the configuration

--- a/docs/stacks.yaml
+++ b/docs/stacks.yaml
@@ -11,12 +11,18 @@ stack-name:
   # The repo branch to checkout from the stack repo
   # before deploying or updating stack
   branch: main
-  # The path to the docker compose file where stack
-  # is defined
-  compose_file: /path/to/compose.yaml
+  # Canonical field: ordered list of compose files
+  # passed to `docker stack deploy -c` in this order.
+  # Later files override earlier ones.
+  compose_files:
+    - /path/to/base.compose.yaml
+    - /path/to/override.compose.yaml
+  # Legacy fallback field (backward compatibility only).
+  # Do not set together with compose_files.
+  # compose_file: /path/to/compose.yaml
   # Path to values file to use when rendering
-  # compose file as a Go template. If empty, compose
-  # file will be treated as a regular compose file
+  # compose files as Go templates. If empty, compose
+  # files are treated as regular compose files.
   values_file: /path/to/values.yaml
   # Paths to files encrypted using sops to decrypt
   # before updating stack

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/goccy/go-yaml v1.12.0
 	github.com/samber/slog-gin v1.13.3
 	github.com/spf13/viper v1.19.0
-	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -55,7 +54,6 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
@@ -98,7 +96,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/goccy/go-yaml v1.12.0
 	github.com/samber/slog-gin v1.13.3
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -54,6 +55,7 @@ require (
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
@@ -96,6 +98,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
@@ -171,7 +174,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/swarmcd/repo.go
+++ b/swarmcd/repo.go
@@ -63,6 +63,12 @@ func (repo *stackRepo) pullChanges(branch string) (revision string, err error) {
 		return "", fmt.Errorf("could not get %s repo worktree: %w", repo.name, err)
 	}
 
+	log.Debug("removing untracked changes...")
+	err = workTree.Clean(&git.CleanOptions{Dir: true})
+	if err != nil {
+		log.Warn("could not cleanup repo worktree", "error", err)
+	}
+
 	log.Debug("checking out branch...")
 	err = workTree.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.ReferenceName("refs/remotes/origin/" + branch),

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -65,7 +65,7 @@ func (swarmStack *swarmStack) updateStack() (revision string, err error) {
 	log.Debug("changes pulled", "revision", revision)
 
 	log.Debug("building templating function...")
-	templatingFunction, err := swarmStack.BuildTemplatingFunction()
+	templatingFunction, err := swarmStack.buildTemplatingFunction()
 	if err != nil {
 		return
 	}
@@ -122,9 +122,9 @@ func (swarmStack *swarmStack) composeFilePaths() []string {
 	return composeFiles
 }
 
-type TemplatingFunction func(composeFile string, composeFileBytes []byte) ([]byte, error)
+type templatingFunction func(composeFile string, composeFileBytes []byte) ([]byte, error)
 
-func (swarmStack *swarmStack) BuildTemplatingFunction() (TemplatingFunction, error) {
+func (swarmStack *swarmStack) buildTemplatingFunction() (templatingFunction, error) {
 	if swarmStack.valuesFile != "" {
 		valuesMap, err := swarmStack.readValuesFile()
 		if err != nil {
@@ -159,7 +159,7 @@ type composeArtifact struct {
 	composeMap map[string]any
 }
 
-func readComposeArtifacts(composeFilePaths []string, templatingFunction TemplatingFunction) ([]composeArtifact, error) {
+func readComposeArtifacts(composeFilePaths []string, templatingFunction templatingFunction) ([]composeArtifact, error) {
 	composeArtifacts := make([]composeArtifact, 0, len(composeFilePaths))
 	for _, composeFile := range composeFilePaths {
 		composeMap, err := ReadStackFile(composeFile, templatingFunction)
@@ -174,7 +174,7 @@ func readComposeArtifacts(composeFilePaths []string, templatingFunction Templati
 	return composeArtifacts, nil
 }
 
-func ReadStackFile(composeFile string, templatingFunction TemplatingFunction) (map[string]any, error) {
+func ReadStackFile(composeFile string, templatingFunction templatingFunction) (map[string]any, error) {
 	composeFileBytes, err := os.ReadFile(composeFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read compose file %s: %w", composeFile, err)

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -257,8 +257,8 @@ func (swarmStack *swarmStack) resolveSopsFilesForDecryption(composeArtifacts []c
 
 func discoverSecretsFromComposeFiles(composeArtifacts []composeArtifact) ([]string, error) {
 	sopsFiles := make([]string, 0)
+	composeDir := path.Dir(composeArtifacts[0].sourcePath)
 	for _, composeArtifact := range composeArtifacts {
-		composeDir := path.Dir(composeArtifact.sourcePath)
 		composeSopsFiles, err := discoverSecrets(composeArtifact.composeMap, composeDir)
 		if err != nil {
 			return nil, err

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -243,7 +243,7 @@ func (swarmStack *swarmStack) resolveSopsFilesForDecryption(composeArtifacts []c
 	seen := make(map[string]struct{}, len(sopsFiles))
 	for _, sopsFile := range sopsFiles {
 		secretFilePath := sopsFile
-		if !path.IsAbs(secretFilePath) {
+		if !swarmStack.discoverSecrets && !path.IsAbs(secretFilePath) {
 			secretFilePath = path.Join(swarmStack.repo.path, secretFilePath)
 		}
 		if _, ok := seen[secretFilePath]; ok {

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -18,19 +18,19 @@ type swarmStack struct {
 	name                 string
 	repo                 *stackRepo
 	branch               string
-	composePath          string
+	composePaths         []string
 	sopsFiles            []string
 	valuesFile           string
 	discoverSecrets      bool
 	alwaysPullContainers *bool
 }
 
-func newSwarmStack(name string, repo *stackRepo, branch string, composePath string, sopsFiles []string, valuesFile string, discoverSecrets bool, alwaysPullContainers *bool) *swarmStack {
+func newSwarmStack(name string, repo *stackRepo, branch string, composePaths []string, sopsFiles []string, valuesFile string, discoverSecrets bool, alwaysPullContainers *bool) *swarmStack {
 	return &swarmStack{
 		name:                 name,
 		repo:                 repo,
 		branch:               branch,
-		composePath:          composePath,
+		composePaths:         composePaths,
 		sopsFiles:            sopsFiles,
 		valuesFile:           valuesFile,
 		discoverSecrets:      discoverSecrets,
@@ -43,7 +43,7 @@ func newSwarmStackFromConfig(name string, repo *stackRepo, stackConfig *util.Sta
 		name,
 		repo,
 		stackConfig.Branch,
-		stackConfig.ComposeFile,
+		stackConfig.ComposeFileChain(),
 		stackConfig.SopsFiles,
 		stackConfig.ValuesFile,
 		globalSecretsDiscovery || stackConfig.SopsSecretsDiscovery,
@@ -64,81 +64,142 @@ func (swarmStack *swarmStack) updateStack() (revision string, err error) {
 	}
 	log.Debug("changes pulled", "revision", revision)
 
-	log.Debug("reading stack file...")
-	stackBytes, err := swarmStack.readStack()
+	log.Debug("building templating function...")
+	templatingFunction, err := swarmStack.BuildTemplatingFunction()
 	if err != nil {
 		return
 	}
 
-	if swarmStack.valuesFile != "" {
-		log.Debug("rendering template...")
-		stackBytes, err = swarmStack.renderComposeTemplate(stackBytes)
-	}
-	if err != nil {
-		return
-	}
-
-	log.Debug("parsing stack content...")
-	stackContents, err := swarmStack.parseStackString([]byte(stackBytes))
+	log.Debug("reading compose chain...")
+	composeArtifacts, err := readComposeArtifacts(swarmStack.composeFilePaths(), templatingFunction)
 	if err != nil {
 		return
 	}
 
 	log.Debug("decrypting secrets...")
-	err = swarmStack.decryptSopsFiles(stackContents)
+	err = swarmStack.decryptSopsFiles(composeArtifacts)
 	if err != nil {
 		return "", fmt.Errorf("failed to decrypt one or more sops files for %s stack: %w", swarmStack.name, err)
 	}
 
 	if config.AutoRotate {
 		log.Debug("rotating configs and secrets...")
-		err = swarmStack.rotateConfigsAndSecrets(stackContents)
-		if err != nil {
-			return
+		for _, composeArtifact := range composeArtifacts {
+			err = swarmStack.rotateConfigsAndSecrets(composeArtifact.composeMap, path.Dir(composeArtifact.sourcePath))
+			if err != nil {
+				return
+			}
 		}
 	}
 
-	log.Debug("writing stack to file...")
-	err = swarmStack.writeStack(stackContents)
-	if err != nil {
-		return
+	deploymentArtifacts := make([]string, 0, len(composeArtifacts))
+	defer func() {
+		for _, deploymentArtifact := range deploymentArtifacts {
+			_ = os.Remove(deploymentArtifact)
+		}
+	}()
+
+	log.Debug("writing deployment artifacts...")
+	for _, composeArtifact := range composeArtifacts {
+		deploymentArtifact, writeErr := swarmStack.writeDeploymentArtifact(composeArtifact.composeMap, composeArtifact.sourcePath)
+		if writeErr != nil {
+			err = writeErr
+			return
+		}
+		deploymentArtifacts = append(deploymentArtifacts, deploymentArtifact)
 	}
 
 	log.Debug("deploying stack...")
-	err = swarmStack.deployStack()
+	err = swarmStack.deployStack(deploymentArtifacts)
 	return
 }
 
-func (swarmStack *swarmStack) readStack() ([]byte, error) {
-	composeFile := path.Join(swarmStack.repo.path, swarmStack.composePath)
-	composeFileBytes, err := os.ReadFile(composeFile)
-	if err != nil {
-		return nil, fmt.Errorf("could not read compose file %s: %w", composeFile, err)
+func (swarmStack *swarmStack) composeFilePaths() []string {
+	composeFiles := make([]string, 0, len(swarmStack.composePaths))
+	for _, composePath := range swarmStack.composePaths {
+		composeFiles = append(composeFiles, path.Join(swarmStack.repo.path, composePath))
 	}
-	return composeFileBytes, nil
+	return composeFiles
 }
 
-func (swarmStack *swarmStack) renderComposeTemplate(templateContents []byte) ([]byte, error) {
+type TemplatingFunction func(composeFile string, composeFileBytes []byte) ([]byte, error)
+
+func (swarmStack *swarmStack) BuildTemplatingFunction() (TemplatingFunction, error) {
+	if swarmStack.valuesFile != "" {
+		valuesMap, err := swarmStack.readValuesFile()
+		if err != nil {
+			return nil, err
+		}
+		return func(composeFile string, composeFileBytes []byte) ([]byte, error) {
+			return swarmStack.renderComposeTemplate(composeFile, composeFileBytes, valuesMap)
+		}, nil
+	} else {
+		return func(composeFile string, composeFileBytes []byte) ([]byte, error) {
+			return composeFileBytes, nil
+		}, nil
+	}
+}
+
+func (swarmStack *swarmStack) readValuesFile() (map[string]any, error) {
 	valuesFile := path.Join(swarmStack.repo.path, swarmStack.valuesFile)
 	valuesBytes, err := os.ReadFile(valuesFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read %s stack values file: %w", swarmStack.name, err)
 	}
 	var valuesMap map[string]any
-	yaml.Unmarshal(valuesBytes, &valuesMap)
-	templ, err := template.New(swarmStack.name).Parse(string(templateContents[:]))
+	err = yaml.Unmarshal(valuesBytes, &valuesMap)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse %s stack compose file as a Go template: %w", swarmStack.name, err)
+		return nil, fmt.Errorf("could not parse %s stack values file as yaml: %w", swarmStack.name, err)
+	}
+	return valuesMap, nil
+}
+
+type composeArtifact struct {
+	sourcePath string
+	composeMap map[string]any
+}
+
+func readComposeArtifacts(composeFilePaths []string, templatingFunction TemplatingFunction) ([]composeArtifact, error) {
+	composeArtifacts := make([]composeArtifact, 0, len(composeFilePaths))
+	for _, composeFile := range composeFilePaths {
+		composeMap, err := ReadStackFile(composeFile, templatingFunction)
+		if err != nil {
+			return nil, err
+		}
+		composeArtifacts = append(composeArtifacts, composeArtifact{
+			sourcePath: composeFile,
+			composeMap: composeMap,
+		})
+	}
+	return composeArtifacts, nil
+}
+
+func ReadStackFile(composeFile string, templatingFunction TemplatingFunction) (map[string]any, error) {
+	composeFileBytes, err := os.ReadFile(composeFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read compose file %s: %w", composeFile, err)
+	}
+	composeFileBytes, err = templatingFunction(composeFile, composeFileBytes)
+	if err != nil {
+		return nil, err
+	}
+	return parseStackString(composeFileBytes)
+}
+
+func (swarmStack *swarmStack) renderComposeTemplate(composeFilePath string, templateContents []byte, valuesMap map[string]any) ([]byte, error) {
+	templ, err := template.New(swarmStack.name).Parse(string(templateContents))
+	if err != nil {
+		return nil, fmt.Errorf("could not parse compose file %s as a Go template for %s stack: %w", composeFilePath, swarmStack.name, err)
 	}
 	var stackContents bytes.Buffer
 	err = templ.Execute(&stackContents, map[string]map[string]any{"Values": valuesMap})
 	if err != nil {
-		return nil, fmt.Errorf("error rending %s stack compose template: %w", swarmStack.name, err)
+		return nil, fmt.Errorf("error rendering compose template %s for %s stack: %w", composeFilePath, swarmStack.name, err)
 	}
 	return stackContents.Bytes(), nil
 }
 
-func (swarmStack *swarmStack) parseStackString(stackContent []byte) (map[string]any, error) {
+func parseStackString(stackContent []byte) (map[string]any, error) {
 	var composeMap map[string]any
 	err := yaml.Unmarshal(stackContent, &composeMap)
 	if err != nil {
@@ -147,15 +208,10 @@ func (swarmStack *swarmStack) parseStackString(stackContent []byte) (map[string]
 	return composeMap, nil
 }
 
-func (swarmStack *swarmStack) decryptSopsFiles(composeMap map[string]any) (err error) {
-	var sopsFiles []string
-	if !swarmStack.discoverSecrets {
-		sopsFiles = swarmStack.sopsFiles
-	} else {
-		sopsFiles, err = discoverSecrets(composeMap, swarmStack.composePath)
-		if err != nil {
-			return
-		}
+func (swarmStack *swarmStack) decryptSopsFiles(composeArtifacts []composeArtifact) (err error) {
+	sopsFiles, err := swarmStack.resolveSopsFilesForDecryption(composeArtifacts)
+	if err != nil {
+		return
 	}
 	log := logger.With(
 		slog.String("stack", swarmStack.name),
@@ -163,12 +219,53 @@ func (swarmStack *swarmStack) decryptSopsFiles(composeMap map[string]any) (err e
 	)
 	for _, sopsFile := range sopsFiles {
 		log.Debug("decrypting secret...", "secret", sopsFile)
-		err = util.DecryptFile(path.Join(swarmStack.repo.path, sopsFile))
+		err = util.DecryptFile(sopsFile)
 		if err != nil {
 			return
 		}
 	}
 	return
+}
+
+func (swarmStack *swarmStack) resolveSopsFilesForDecryption(composeArtifacts []composeArtifact) ([]string, error) {
+	var sopsFiles []string
+	if !swarmStack.discoverSecrets {
+		sopsFiles = swarmStack.sopsFiles
+	} else {
+		var err error
+		sopsFiles, err = discoverSecretsFromComposeFiles(composeArtifacts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resolvedPaths := make([]string, 0, len(sopsFiles))
+	seen := make(map[string]struct{}, len(sopsFiles))
+	for _, sopsFile := range sopsFiles {
+		secretFilePath := sopsFile
+		if !path.IsAbs(secretFilePath) {
+			secretFilePath = path.Join(swarmStack.repo.path, secretFilePath)
+		}
+		if _, ok := seen[secretFilePath]; ok {
+			continue
+		}
+		seen[secretFilePath] = struct{}{}
+		resolvedPaths = append(resolvedPaths, secretFilePath)
+	}
+	return resolvedPaths, nil
+}
+
+func discoverSecretsFromComposeFiles(composeArtifacts []composeArtifact) ([]string, error) {
+	sopsFiles := make([]string, 0)
+	for _, composeArtifact := range composeArtifacts {
+		composeDir := path.Dir(composeArtifact.sourcePath)
+		composeSopsFiles, err := discoverSecrets(composeArtifact.composeMap, composeDir)
+		if err != nil {
+			return nil, err
+		}
+		sopsFiles = append(sopsFiles, composeSopsFiles...)
+	}
+	return sopsFiles, nil
 }
 
 // filters objects to only those with a "file" key, validating
@@ -203,22 +300,25 @@ func discoverSecrets(composeMap map[string]any, composePath string) ([]string, e
 		}
 		for _, secretMap := range fileObjects {
 			secretFile := secretMap["file"].(string)
-			secretPath := path.Join(path.Dir(composePath), secretFile)
+			secretPath := secretFile
+			if !path.IsAbs(secretPath) {
+				secretPath = path.Join(composePath, secretPath)
+			}
 			sopsFiles = append(sopsFiles, secretPath)
 		}
 	}
 	return sopsFiles, nil
 }
 
-func (swarmStack *swarmStack) rotateConfigsAndSecrets(composeMap map[string]any) error {
+func (swarmStack *swarmStack) rotateConfigsAndSecrets(composeMap map[string]any, composeDir string) error {
 	if configs, ok := composeMap["configs"].(map[string]any); ok {
-		err := swarmStack.rotateObjects(configs, "configs")
+		err := swarmStack.rotateObjects(configs, "configs", composeDir)
 		if err != nil {
 			return fmt.Errorf("could not rotate one or more config files of stack %s: %w", swarmStack.name, err)
 		}
 	}
 	if secrets, ok := composeMap["secrets"].(map[string]any); ok {
-		err := swarmStack.rotateObjects(secrets, "secrets")
+		err := swarmStack.rotateObjects(secrets, "secrets", composeDir)
 		if err != nil {
 			return fmt.Errorf("could not rotate one or more secret files of stack %s: %w", swarmStack.name, err)
 		}
@@ -226,8 +326,7 @@ func (swarmStack *swarmStack) rotateConfigsAndSecrets(composeMap map[string]any)
 	return nil
 }
 
-func (swarmStack *swarmStack) rotateObjects(objects map[string]any, objectType string) error {
-	objectsDir := path.Dir(path.Join(swarmStack.repo.path, swarmStack.composePath))
+func (swarmStack *swarmStack) rotateObjects(objects map[string]any, objectType string, objectsDir string) error {
 	fileObjects, err := getFileObjects(objects)
 	if err != nil {
 		return err
@@ -240,7 +339,10 @@ func (swarmStack *swarmStack) rotateObjects(objects map[string]any, objectType s
 		)
 		objectFile := objectMap["file"].(string)
 		log.Debug("reading...", "file", objectFile)
-		objectFilePath := path.Join(objectsDir, objectFile)
+		objectFilePath := objectFile
+		if !path.IsAbs(objectFilePath) {
+			objectFilePath = path.Join(objectsDir, objectFilePath)
+		}
 		configFileBytes, err := os.ReadFile(objectFilePath)
 		if err != nil {
 			return fmt.Errorf("could not read file %s for rotation: %w", objectFilePath, err)
@@ -254,34 +356,55 @@ func (swarmStack *swarmStack) rotateObjects(objects map[string]any, objectType s
 	return nil
 }
 
-func (swarmStack *swarmStack) writeStack(composeMap map[string]any) error {
+func (swarmStack *swarmStack) writeDeploymentArtifact(composeMap map[string]any, composeSourcePath string) (string, error) {
 	composeFileBytes, err := yaml.Marshal(composeMap)
 	if err != nil {
-		return fmt.Errorf("could not store compose file as yaml after calculating hashes for stack %s", swarmStack.name)
+		return "", fmt.Errorf("could not store compose file as yaml after calculating hashes for stack %s", swarmStack.name)
 	}
-	composeFile := path.Join(swarmStack.repo.path, swarmStack.composePath)
-	fileInfo, _ := os.Stat(composeFile)
-	os.WriteFile(composeFile, composeFileBytes, fileInfo.Mode())
-	return nil
+
+	composeDir := path.Dir(composeSourcePath)
+	deploymentArtifact, err := os.CreateTemp(composeDir, fmt.Sprintf(".swarmcd-deploy-%s-*.yaml", swarmStack.name))
+	if err != nil {
+		return "", fmt.Errorf("could not create deployment artifact for stack %s: %w", swarmStack.name, err)
+	}
+
+	if _, err = deploymentArtifact.Write(composeFileBytes); err != nil {
+		deploymentArtifact.Close()
+		os.Remove(deploymentArtifact.Name())
+		return "", fmt.Errorf("could not write deployment artifact for stack %s: %w", swarmStack.name, err)
+	}
+
+	if err = deploymentArtifact.Close(); err != nil {
+		os.Remove(deploymentArtifact.Name())
+		return "", fmt.Errorf("could not close deployment artifact for stack %s: %w", swarmStack.name, err)
+	}
+
+	return deploymentArtifact.Name(), nil
 }
 
-func (swarmStack *swarmStack) deployStack() error {
+func (swarmStack *swarmStack) deployStack(composeFiles []string) error {
 	cmd := stack.NewStackCommand(dockerCli)
-	cmd.SetArgs([]string{
-		"deploy", "--detach", "--with-registry-auth",
-		"--resolve-image", swarmStack.resolveImageMode(),
-		"-c", path.Join(swarmStack.repo.path, swarmStack.composePath),
-		swarmStack.name,
-	})
+	cmd.SetArgs(swarmStack.deployStackArgs(composeFiles))
 	// To stop printing errors and
 	// usage message to stdout
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	err := cmd.Execute()
 	if err != nil {
-		return fmt.Errorf("could not deploy stack %s: %s", swarmStack.name, err)
+		return fmt.Errorf("could not deploy stack %s: %w", swarmStack.name, err)
 	}
 	return nil
+}
+
+func (swarmStack *swarmStack) deployStackArgs(composeFiles []string) []string {
+	args := []string{
+		"deploy", "--detach", "--with-registry-auth",
+		"--resolve-image", swarmStack.resolveImageMode(),
+	}
+	for _, composeFile := range composeFiles {
+		args = append(args, "-c", composeFile)
+	}
+	return append(args, swarmStack.name)
 }
 
 // Returns "always" when alwaysPullContainers is true, "changed" otherwise.

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -1,16 +1,20 @@
 package swarmcd
 
 import (
+	"os"
+	"path"
+	"slices"
 	"sync"
 	"testing"
 
 	"github.com/m-adawi/swarm-cd/util"
+	"github.com/stretchr/testify/require"
 )
-
-func boolPtr(v bool) *bool { return &v }
 
 // test all the possible combinations of config and stack AlwaysPullContainers settings.
 func TestResolveImageMode(t *testing.T) {
+	stackFalse := false
+	stackTrue := true
 	tests := []struct {
 		name           string
 		configPull     bool
@@ -21,10 +25,10 @@ func TestResolveImageMode(t *testing.T) {
 		{"config=false stack=unset", false, nil, "changed"},
 		{"config=true  stack=unset", true, nil, "always"},
 		// Stack setting is explicit: overrides global config
-		{"config=false stack=false", false, boolPtr(false), "changed"},
-		{"config=false stack=true", false, boolPtr(true), "always"},
-		{"config=true  stack=false", true, boolPtr(false), "changed"},
-		{"config=true  stack=true", true, boolPtr(true), "always"},
+		{"config=false stack=false", false, &stackFalse, "changed"},
+		{"config=false stack=true", false, &stackTrue, "always"},
+		{"config=true  stack=false", true, &stackFalse, "changed"},
+		{"config=true  stack=true", true, &stackTrue, "always"},
 	}
 
 	for _, tt := range tests {
@@ -36,7 +40,7 @@ func TestResolveImageMode(t *testing.T) {
 			t.Cleanup(func() { config = originalConfig })
 
 			repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-			s := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false, tt.stackPull)
+			s := newSwarmStack("test", repo, "main", []string{"docker-compose.yaml"}, nil, "", false, tt.stackPull)
 
 			got := s.resolveImageMode()
 			if got != tt.expectedResult {
@@ -46,26 +50,22 @@ func TestResolveImageMode(t *testing.T) {
 	}
 }
 
-// Non-file objects are ignored by the rotation
+// Non-file objects are ignored by the rotation.
 func TestRotateObjectsWithoutFile(t *testing.T) {
 	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "docker-compose.yaml", nil, "", false, nil)
+	stack := newSwarmStack("test", repo, "main", []string{"docker-compose.yaml"}, nil, "", false, nil)
 	objects := map[string]any{
 		"my-secret": map[string]any{"external": true},
 		"my-plugin-external-secret": map[string]any{
 			"driver": "my-driver", "labels": map[string]string{"my_option": "value"},
 		},
 	}
-	err := stack.rotateObjects(objects, "secrets")
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
+	err := stack.rotateObjects(objects, "secrets", t.TempDir())
+	require.NoError(t, err)
 }
 
-// Secrets are discovered, external secrets are ignored
+// Secrets are discovered, external secrets are ignored.
 func TestSecretDiscovery(t *testing.T) {
-	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
-	stack := newSwarmStack("test", repo, "main", "stacks/docker-compose.yaml", nil, "", false, nil)
 	stackString := []byte(`services:
   my-service:
     image: my-image
@@ -82,21 +82,126 @@ secrets:
     labels:
       my_option: value
 `)
-	composeMap, err := stack.parseStackString(stackString)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-		return
+	composeMap, err := parseStackString(stackString)
+	require.NoError(t, err)
+
+	sopsFiles, err := discoverSecrets(composeMap, "stacks")
+	require.NoError(t, err)
+	require.Equal(t, []string{"stacks/secrets/secret.yaml"}, sopsFiles)
+}
+
+// Secret file paths that are already absolute stay absolute.
+func TestSecretDiscoveryKeepsAbsolutePaths(t *testing.T) {
+	stackString := []byte(`secrets:
+  absolute-secret:
+    file: /run/secrets/absolute.yaml
+  relative-secret:
+    file: secrets/relative.yaml
+`)
+	composeMap, err := parseStackString(stackString)
+	require.NoError(t, err)
+
+	sopsFiles, err := discoverSecrets(composeMap, "stacks")
+	require.NoError(t, err)
+	require.Len(t, sopsFiles, 2)
+	require.True(t, slices.Contains(sopsFiles, "/run/secrets/absolute.yaml"))
+	require.True(t, slices.Contains(sopsFiles, "stacks/secrets/relative.yaml"))
+}
+
+func TestDiscoverSecretsFromComposeFilesUsesEachComposeDirectory(t *testing.T) {
+	composeArtifacts := []composeArtifact{
+		{
+			sourcePath: "/repo/tenant-a/compose.yaml",
+			composeMap: map[string]any{
+				"secrets": map[string]any{
+					"tenant-a-secret": map[string]any{"file": "secrets/tenant-a.enc.yaml"},
+				},
+			},
+		},
+		{
+			sourcePath: "/repo/tenant-b/compose.yaml",
+			composeMap: map[string]any{
+				"secrets": map[string]any{
+					"tenant-b-secret": map[string]any{"file": "secrets/tenant-b.enc.yaml"},
+				},
+			},
+		},
 	}
-	sopsFiles, err := discoverSecrets(composeMap, stack.composePath)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-		return
+
+	sopsFiles, err := discoverSecretsFromComposeFiles(composeArtifacts)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"/repo/tenant-a/secrets/tenant-a.enc.yaml",
+		"/repo/tenant-b/secrets/tenant-b.enc.yaml",
+	}, sopsFiles)
+}
+
+func TestResolveSopsFilesForDecryptionDeduplicatesDiscoveredPaths(t *testing.T) {
+	repoPath := t.TempDir()
+	repo := &stackRepo{name: "test", path: repoPath, url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "main", []string{"compose-a.yaml", "compose-b.yaml"}, nil, "", true, nil)
+
+	composeArtifacts := []composeArtifact{
+		{
+			sourcePath: path.Join(repoPath, "tenant", "compose-a.yaml"),
+			composeMap: map[string]any{
+				"secrets": map[string]any{
+					"shared-secret-a": map[string]any{"file": "secrets/shared.enc.yaml"},
+				},
+			},
+		},
+		{
+			sourcePath: path.Join(repoPath, "tenant", "compose-b.yaml"),
+			composeMap: map[string]any{
+				"secrets": map[string]any{
+					"shared-secret-b": map[string]any{"file": "secrets/shared.enc.yaml"},
+				},
+			},
+		},
 	}
-	if len(sopsFiles) != 1 {
-		t.Errorf("unexpected number of sops files: %d", len(sopsFiles))
-		return
-	}
-	if sopsFiles[0] != "stacks/secrets/secret.yaml" {
-		t.Errorf("unexpected sops file: %s", sopsFiles[0])
-	}
+
+	resolvedPaths, err := stack.resolveSopsFilesForDecryption(composeArtifacts)
+	require.NoError(t, err)
+	require.Equal(t, []string{path.Join(repoPath, "tenant", "secrets", "shared.enc.yaml")}, resolvedPaths)
+}
+
+func TestWriteDeploymentArtifactUsesSourceComposeDirectory(t *testing.T) {
+	repoPath := t.TempDir()
+	composeDir := path.Join(repoPath, "tenant")
+	require.NoError(t, os.MkdirAll(composeDir, 0o755))
+
+	repo := &stackRepo{name: "test", path: repoPath, url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test", repo, "main", []string{"tenant/compose.yaml"}, nil, "", false, nil)
+
+	artifactPath, err := stack.writeDeploymentArtifact(map[string]any{
+		"services": map[string]any{
+			"app": map[string]any{"image": "nginx"},
+		},
+	}, path.Join(composeDir, "compose.yaml"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(artifactPath) })
+
+	require.Equal(t, composeDir, path.Dir(artifactPath))
+	artifactInfo, err := os.Stat(artifactPath)
+	require.NoError(t, err)
+	require.False(t, artifactInfo.IsDir())
+}
+
+func TestDeployStackArgsPreservesConfiguredOrderAndRepeats(t *testing.T) {
+	originalConfig := config
+	config = &util.Config{AlwaysPullContainers: true}
+	t.Cleanup(func() { config = originalConfig })
+
+	repo := &stackRepo{name: "test", path: "test", url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
+	stack := newSwarmStack("test-stack", repo, "main", []string{"a.yaml", "b.yaml"}, nil, "", false, nil)
+
+	args := stack.deployStackArgs([]string{"a.yaml", "b.yaml", "a.yaml"})
+	require.Equal(t, []string{
+		"deploy", "--detach", "--with-registry-auth",
+		"--resolve-image", "always",
+		"-c", "a.yaml",
+		"-c", "b.yaml",
+		"-c", "a.yaml",
+		"test-stack",
+	}, args)
 }

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -158,7 +158,7 @@ func TestDiscoverSecretsFromComposeFilesUsesFirstComposeDirectory(t *testing.T) 
 }
 
 func TestResolveSopsFilesForDecryptionDeduplicatesDiscoveredPaths(t *testing.T) {
-	repoPath := t.TempDir()
+	repoPath := "repos/repo"
 	repo := &stackRepo{name: "test", path: repoPath, url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 	stack := newSwarmStack("test", repo, "main", []string{"compose-a.yaml", "compose-b.yaml"}, nil, "", true, nil)
 

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -124,7 +124,7 @@ func TestSecretDiscoveryKeepsAbsolutePaths(t *testing.T) {
 	}
 }
 
-func TestDiscoverSecretsFromComposeFilesUsesEachComposeDirectory(t *testing.T) {
+func TestDiscoverSecretsFromComposeFilesUsesFirstComposeDirectory(t *testing.T) {
 	composeArtifacts := []composeArtifact{
 		{
 			sourcePath: "/repo/tenant-a/compose.yaml",
@@ -150,7 +150,7 @@ func TestDiscoverSecretsFromComposeFilesUsesEachComposeDirectory(t *testing.T) {
 	}
 	want := []string{
 		"/repo/tenant-a/secrets/tenant-a.enc.yaml",
-		"/repo/tenant-b/secrets/tenant-b.enc.yaml",
+		"/repo/tenant-a/secrets/tenant-b.enc.yaml",
 	}
 	if !slices.Equal(sopsFiles, want) {
 		t.Errorf("discoverSecretsFromComposeFiles() = %v, want %v", sopsFiles, want)

--- a/swarmcd/stack_test.go
+++ b/swarmcd/stack_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/m-adawi/swarm-cd/util"
-	"github.com/stretchr/testify/require"
 )
 
 // test all the possible combinations of config and stack AlwaysPullContainers settings.
@@ -60,8 +59,9 @@ func TestRotateObjectsWithoutFile(t *testing.T) {
 			"driver": "my-driver", "labels": map[string]string{"my_option": "value"},
 		},
 	}
-	err := stack.rotateObjects(objects, "secrets", t.TempDir())
-	require.NoError(t, err)
+	if err := stack.rotateObjects(objects, "secrets", t.TempDir()); err != nil {
+		t.Fatalf("rotateObjects() error: %v", err)
+	}
 }
 
 // Secrets are discovered, external secrets are ignored.
@@ -83,11 +83,17 @@ secrets:
       my_option: value
 `)
 	composeMap, err := parseStackString(stackString)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("parseStackString() error: %v", err)
+	}
 
 	sopsFiles, err := discoverSecrets(composeMap, "stacks")
-	require.NoError(t, err)
-	require.Equal(t, []string{"stacks/secrets/secret.yaml"}, sopsFiles)
+	if err != nil {
+		t.Fatalf("discoverSecrets() error: %v", err)
+	}
+	if !slices.Equal(sopsFiles, []string{"stacks/secrets/secret.yaml"}) {
+		t.Errorf("discoverSecrets() = %v, want %v", sopsFiles, []string{"stacks/secrets/secret.yaml"})
+	}
 }
 
 // Secret file paths that are already absolute stay absolute.
@@ -99,13 +105,23 @@ func TestSecretDiscoveryKeepsAbsolutePaths(t *testing.T) {
     file: secrets/relative.yaml
 `)
 	composeMap, err := parseStackString(stackString)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("parseStackString() error: %v", err)
+	}
 
 	sopsFiles, err := discoverSecrets(composeMap, "stacks")
-	require.NoError(t, err)
-	require.Len(t, sopsFiles, 2)
-	require.True(t, slices.Contains(sopsFiles, "/run/secrets/absolute.yaml"))
-	require.True(t, slices.Contains(sopsFiles, "stacks/secrets/relative.yaml"))
+	if err != nil {
+		t.Fatalf("discoverSecrets() error: %v", err)
+	}
+	if len(sopsFiles) != 2 {
+		t.Fatalf("discoverSecrets() len = %d, want 2", len(sopsFiles))
+	}
+	if !slices.Contains(sopsFiles, "/run/secrets/absolute.yaml") {
+		t.Errorf("discoverSecrets() = %v, missing %q", sopsFiles, "/run/secrets/absolute.yaml")
+	}
+	if !slices.Contains(sopsFiles, "stacks/secrets/relative.yaml") {
+		t.Errorf("discoverSecrets() = %v, missing %q", sopsFiles, "stacks/secrets/relative.yaml")
+	}
 }
 
 func TestDiscoverSecretsFromComposeFilesUsesEachComposeDirectory(t *testing.T) {
@@ -129,11 +145,16 @@ func TestDiscoverSecretsFromComposeFilesUsesEachComposeDirectory(t *testing.T) {
 	}
 
 	sopsFiles, err := discoverSecretsFromComposeFiles(composeArtifacts)
-	require.NoError(t, err)
-	require.Equal(t, []string{
+	if err != nil {
+		t.Fatalf("discoverSecretsFromComposeFiles() error: %v", err)
+	}
+	want := []string{
 		"/repo/tenant-a/secrets/tenant-a.enc.yaml",
 		"/repo/tenant-b/secrets/tenant-b.enc.yaml",
-	}, sopsFiles)
+	}
+	if !slices.Equal(sopsFiles, want) {
+		t.Errorf("discoverSecretsFromComposeFiles() = %v, want %v", sopsFiles, want)
+	}
 }
 
 func TestResolveSopsFilesForDecryptionDeduplicatesDiscoveredPaths(t *testing.T) {
@@ -161,14 +182,21 @@ func TestResolveSopsFilesForDecryptionDeduplicatesDiscoveredPaths(t *testing.T) 
 	}
 
 	resolvedPaths, err := stack.resolveSopsFilesForDecryption(composeArtifacts)
-	require.NoError(t, err)
-	require.Equal(t, []string{path.Join(repoPath, "tenant", "secrets", "shared.enc.yaml")}, resolvedPaths)
+	if err != nil {
+		t.Fatalf("resolveSopsFilesForDecryption() error: %v", err)
+	}
+	want := []string{path.Join(repoPath, "tenant", "secrets", "shared.enc.yaml")}
+	if !slices.Equal(resolvedPaths, want) {
+		t.Errorf("resolveSopsFilesForDecryption() = %v, want %v", resolvedPaths, want)
+	}
 }
 
 func TestWriteDeploymentArtifactUsesSourceComposeDirectory(t *testing.T) {
 	repoPath := t.TempDir()
 	composeDir := path.Join(repoPath, "tenant")
-	require.NoError(t, os.MkdirAll(composeDir, 0o755))
+	if err := os.MkdirAll(composeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
 
 	repo := &stackRepo{name: "test", path: repoPath, url: "", auth: nil, lock: &sync.Mutex{}, gitRepoObject: nil}
 	stack := newSwarmStack("test", repo, "main", []string{"tenant/compose.yaml"}, nil, "", false, nil)
@@ -178,13 +206,21 @@ func TestWriteDeploymentArtifactUsesSourceComposeDirectory(t *testing.T) {
 			"app": map[string]any{"image": "nginx"},
 		},
 	}, path.Join(composeDir, "compose.yaml"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("writeDeploymentArtifact() error: %v", err)
+	}
 	t.Cleanup(func() { _ = os.Remove(artifactPath) })
 
-	require.Equal(t, composeDir, path.Dir(artifactPath))
+	if got := path.Dir(artifactPath); got != composeDir {
+		t.Errorf("writeDeploymentArtifact() dir = %q, want %q", got, composeDir)
+	}
 	artifactInfo, err := os.Stat(artifactPath)
-	require.NoError(t, err)
-	require.False(t, artifactInfo.IsDir())
+	if err != nil {
+		t.Fatalf("os.Stat() error: %v", err)
+	}
+	if artifactInfo.IsDir() {
+		t.Errorf("writeDeploymentArtifact() artifact %q is a directory", artifactPath)
+	}
 }
 
 func TestDeployStackArgsPreservesConfiguredOrderAndRepeats(t *testing.T) {
@@ -196,12 +232,15 @@ func TestDeployStackArgsPreservesConfiguredOrderAndRepeats(t *testing.T) {
 	stack := newSwarmStack("test-stack", repo, "main", []string{"a.yaml", "b.yaml"}, nil, "", false, nil)
 
 	args := stack.deployStackArgs([]string{"a.yaml", "b.yaml", "a.yaml"})
-	require.Equal(t, []string{
+	want := []string{
 		"deploy", "--detach", "--with-registry-auth",
 		"--resolve-image", "always",
 		"-c", "a.yaml",
 		"-c", "b.yaml",
 		"-c", "a.yaml",
 		"test-stack",
-	}, args)
+	}
+	if !slices.Equal(args, want) {
+		t.Errorf("deployStackArgs() = %v, want %v", args, want)
+	}
 }

--- a/util/config.go
+++ b/util/config.go
@@ -133,8 +133,8 @@ func validateConfig() error {
 		}
 		legacyComposeSet := strings.TrimSpace(stackConfig.ComposeFile) != ""
 		canonicalComposeSet := stackConfig.ComposeFiles != nil
-		if legacyComposeSet && canonicalComposeSet {
-			return fmt.Errorf("invalid stacks config for %s: use either compose_file or compose_files, not both", stackName)
+		if legacyComposeSet == canonicalComposeSet {
+			return fmt.Errorf("invalid stacks config for %s: use either compose_file or compose_files, but not both", stackName)
 		}
 		if canonicalComposeSet {
 			if len(stackConfig.ComposeFiles) == 0 {

--- a/util/config.go
+++ b/util/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -12,10 +13,21 @@ type StackConfig struct {
 	Repo                 string
 	Branch               string
 	ComposeFile          string   `mapstructure:"compose_file"`
+	ComposeFiles         []string `mapstructure:"compose_files"`
 	ValuesFile           string   `mapstructure:"values_file"`
 	SopsFiles            []string `mapstructure:"sops_files"`
 	SopsSecretsDiscovery bool     `mapstructure:"sops_secrets_discovery"`
 	AlwaysPullContainers *bool    `mapstructure:"always_pull_containers"`
+}
+
+func (stackConfig *StackConfig) ComposeFileChain() []string {
+	if len(stackConfig.ComposeFiles) > 0 {
+		return stackConfig.ComposeFiles
+	}
+	if stackConfig.ComposeFile != "" {
+		return []string{stackConfig.ComposeFile}
+	}
+	return nil
 }
 
 type RepoConfig struct {
@@ -58,8 +70,7 @@ func LoadConfigs() (err error) {
 			return fmt.Errorf("could not load stacks file: %w", err)
 		}
 	}
-	validateConfig()
-	return nil
+	return validateConfig()
 }
 
 func getConfigsPath() string {
@@ -111,9 +122,30 @@ func readStackConfigs(path string) (err error) {
 	return stacksViper.Unmarshal(&Configs.StackConfigs)
 }
 
-func validateConfig() {
+func validateConfig() error {
 	if Configs.Concurrency <= 0 {
 		Logger.Warn(fmt.Sprintf("Invalid `config.concurrency value`, using default: %v", defaultWorkers))
 		Configs.Concurrency = defaultWorkers
 	}
+	for stackName, stackConfig := range Configs.StackConfigs {
+		if stackConfig == nil {
+			return fmt.Errorf("invalid stacks config for %s: stack config must not be empty", stackName)
+		}
+		legacyComposeSet := strings.TrimSpace(stackConfig.ComposeFile) != ""
+		canonicalComposeSet := stackConfig.ComposeFiles != nil
+		if legacyComposeSet && canonicalComposeSet {
+			return fmt.Errorf("invalid stacks config for %s: use either compose_file or compose_files, not both", stackName)
+		}
+		if canonicalComposeSet {
+			if len(stackConfig.ComposeFiles) == 0 {
+				return fmt.Errorf("invalid stacks config for %s: compose_files must not be empty", stackName)
+			}
+			for i, composeFile := range stackConfig.ComposeFiles {
+				if strings.TrimSpace(composeFile) == "" {
+					return fmt.Errorf("invalid stacks config for %s: compose_files[%d] must not be empty", stackName, i)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -104,7 +104,14 @@ func TestValidateConfigComposeFilesRules(t *testing.T) {
 				ComposeFile:  "compose.yaml",
 				ComposeFiles: []string{"base.yaml", "prod.yaml"},
 			},
-			wantError: "use either compose_file or compose_files, not both",
+			wantError: "use either compose_file or compose_files, but not both",
+		},
+		{
+			name: "none of legacy and canonical fields are set",
+			stack: StackConfig{
+				ComposeFile:  "",
+			},
+			wantError: "use either compose_file or compose_files, but not both",
 		},
 		{
 			name: "compose files list is empty",

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"os"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -45,5 +47,141 @@ func TestGetConfigsPath(t *testing.T) {
 				t.Errorf("getConfigsPath() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStackConfigComposeFileChain(t *testing.T) {
+	tests := []struct {
+		name   string
+		config StackConfig
+		want   []string
+	}{
+		{
+			name: "canonical compose files",
+			config: StackConfig{
+				ComposeFiles: []string{"base.yaml", "prod.yaml"},
+			},
+			want: []string{"base.yaml", "prod.yaml"},
+		},
+		{
+			name: "legacy compose file fallback",
+			config: StackConfig{
+				ComposeFile: "compose.yaml",
+			},
+			want: []string{"compose.yaml"},
+		},
+		{
+			name:   "no compose file configured",
+			config: StackConfig{},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.ComposeFileChain()
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("ComposeFileChain() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfigComposeFilesRules(t *testing.T) {
+	originalConfigs := Configs
+	t.Cleanup(func() {
+		Configs = originalConfigs
+	})
+
+	tests := []struct {
+		name      string
+		stack     StackConfig
+		wantError string
+	}{
+		{
+			name: "legacy and canonical fields are both set",
+			stack: StackConfig{
+				ComposeFile:  "compose.yaml",
+				ComposeFiles: []string{"base.yaml", "prod.yaml"},
+			},
+			wantError: "use either compose_file or compose_files, not both",
+		},
+		{
+			name: "compose files list is empty",
+			stack: StackConfig{
+				ComposeFiles: []string{},
+			},
+			wantError: "compose_files must not be empty",
+		},
+		{
+			name: "compose files list contains empty value",
+			stack: StackConfig{
+				ComposeFiles: []string{"base.yaml", ""},
+			},
+			wantError: "compose_files[1] must not be empty",
+		},
+		{
+			name: "valid canonical compose files",
+			stack: StackConfig{
+				ComposeFiles: []string{"base.yaml", "prod.yaml"},
+			},
+		},
+		{
+			name: "valid legacy compose file",
+			stack: StackConfig{
+				ComposeFile: "compose.yaml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stackConfig := tt.stack
+			Configs = Config{
+				Concurrency: defaultWorkers,
+				StackConfigs: map[string]*StackConfig{
+					"test-stack": &stackConfig,
+				},
+			}
+
+			err := validateConfig()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateConfig() returned unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("validateConfig() expected error containing %q, got nil", tt.wantError)
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("validateConfig() error = %q, want substring %q", err.Error(), tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateConfigSetsDefaultConcurrency(t *testing.T) {
+	originalConfigs := Configs
+	t.Cleanup(func() {
+		Configs = originalConfigs
+	})
+
+	Configs = Config{
+		Concurrency: 0,
+		StackConfigs: map[string]*StackConfig{
+			"test-stack": {
+				ComposeFile: "compose.yaml",
+			},
+		},
+	}
+
+	err := validateConfig()
+	if err != nil {
+		t.Fatalf("validateConfig() returned unexpected error: %v", err)
+	}
+	if Configs.Concurrency != defaultWorkers {
+		t.Fatalf("validateConfig() concurrency = %d, want %d", Configs.Concurrency, defaultWorkers)
 	}
 }

--- a/web/controllers.go
+++ b/web/controllers.go
@@ -13,9 +13,9 @@ func getStacks(ctx *gin.Context) {
 	var stacks []map[string]string
 	for k, v := range stacksStatus {
 		stacks = append(stacks, map[string]string{
-			"Name": k,
-			"Error": v.Error,
-			"RepoURL": v.RepoURL,
+			"Name":     k,
+			"Error":    v.Error,
+			"RepoURL":  v.RepoURL,
 			"Revision": v.Revision,
 		})
 	}


### PR DESCRIPTION
After a lot of thinking about the best strategies to handle multiple environments without drifting too much from vanilla swarm/compose, I've settled on splitting the compose files into a base stack.yaml and env-specific ones (stack-staging.yaml and/or stack-production.yaml).

This PR allows us (well, me at least) to pass multiple compose files to the docker stack deploy command.

Disclaimer: this was done with the help of Codex and Matt Pocock's skills, but still with a heavy presence of the human in the loop.

I've introduced a new "compose_files" option that accepts a list of files, and it is mutually exclusive with the legacy "compose_file".

File reading, template rendering, secrets decrypting, secrets/configs rotation are done per single compose file, then they are passed as argument to docker stack deploy command to:
-  avoid naive merging
- avoid another docker cli dependency
- be as close as possible to the vanilla/manual way to do things in swarm.

The resulting compose files are saved as temporary files alongside the original, and this solves an issue with the current implementation: if someone uses the same stack with a different values_file, the second one would read an already rendered compose file and deploy a copy of the first one.

The secret discovery handles absolute paths and caches the already seen files to avoid decryption of an already decrypted secret (if it is used multiple times).

I've also refactored the current templating behavior into a function factory, and moved some of the methods outside of the SwarmStack struct (they didn't depend on any field).

closes #163